### PR TITLE
docs: add Notion API 2000-char limit to content properties

### DIFF
--- a/src/main/java/io/kestra/plugin/notion/page/Create.java
+++ b/src/main/java/io/kestra/plugin/notion/page/Create.java
@@ -93,7 +93,9 @@ public class Create extends NotionConnection implements RunnableTask<Create.Outp
 
     @Schema(
         title = "Page content",
-        description = "Optional markdown content converted to Notion blocks; empty leaves the page body blank"
+        description = """
+            Optional markdown content converted to Notion blocks; empty leaves the page body blank.
+            Note that the Notion API enforces a limit of 2000 characters per [rich text content block](https://developers.notion.com/reference/request-limits)."""
     )
     private Property<String> content;
 

--- a/src/main/java/io/kestra/plugin/notion/page/Update.java
+++ b/src/main/java/io/kestra/plugin/notion/page/Update.java
@@ -91,7 +91,9 @@ public class Update extends AbstractTask {
 
     @Schema(
         title = "New page content",
-        description = "The new content for the page in markdown format. This will be appended to the bottom of the page."
+        description = """
+            The new content for the page in markdown format. This will be appended to the bottom of the page.
+            Note that the Notion API enforces a limit of 2000 characters per [rich text content block](https://developers.notion.com/reference/request-limits)."""
     )
     private Property<String> content;
 


### PR DESCRIPTION
## Summary
- Add a note about the Notion API's 2000 character per rich text content block limit to the `content` property description in `Create` and `Update` tasks
- Include a link to the [Notion API request limits documentation](https://developers.notion.com/reference/request-limits)

## Test plan
- [ ] Verify the `@Schema` descriptions render correctly in the Kestra UI
- [ ] Confirm the markdown link works in generated documentation