### PR TITLE
feat(markdown): add link support to MarkdownConverter

### DIFF
--- a/src/main/java/io/kestra/plugin/notion/utils/MarkdownConverter.java
+++ b/src/main/java/io/kestra/plugin/notion/utils/MarkdownConverter.java
@@ -1,6 +1,7 @@
 package io.kestra.plugin.notion.utils;
 
 import java.util.*;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
@@ -335,33 +336,69 @@ public class MarkdownConverter {
      * Create rich text array from markdown text with basic formatting
      */
     private static ArrayNode createRichTextFromMarkdown(String text) {
-        ArrayNode richText = mapper.createArrayNode();
+        var richText = mapper.createArrayNode();
 
         if (text == null || text.isEmpty()) {
             return richText;
         }
 
-        // For now, create simple rich text without parsing inline formatting
-        // This can be enhanced later to handle bold, italic, links, etc.
-        ObjectNode richTextItem = mapper.createObjectNode();
-        richTextItem.put("type", "text");
+        var matcher = LINK_PATTERN.matcher(text);
+        var lastEnd = 0;
 
-        ObjectNode textObject = mapper.createObjectNode();
-        textObject.put("content", text);
-        richTextItem.set("text", textObject);
+        while (matcher.find()) {
+            if (matcher.start() > lastEnd) {
+                richText.add(createPlainRichTextItem(text.substring(lastEnd, matcher.start())));
+            }
+            var linkText = matcher.group(1);
+            var linkUrl = matcher.group(2);
+            richText.add(createLinkRichTextItem(linkText, linkUrl));
+            lastEnd = matcher.end();
+        }
 
-        ObjectNode annotations = mapper.createObjectNode();
+        if (lastEnd < text.length()) {
+            richText.add(createPlainRichTextItem(text.substring(lastEnd)));
+        }
+
+        return richText;
+    }
+
+    private static ObjectNode createPlainRichTextItem(String content) {
+        var item = mapper.createObjectNode();
+        item.put("type", "text");
+
+        var textObject = mapper.createObjectNode();
+        textObject.put("content", content);
+        item.set("text", textObject);
+
+        item.set("annotations", createDefaultAnnotations());
+        return item;
+    }
+
+    private static ObjectNode createLinkRichTextItem(String content, String url) {
+        var item = mapper.createObjectNode();
+        item.put("type", "text");
+
+        var textObject = mapper.createObjectNode();
+        textObject.put("content", content);
+        var linkObject = mapper.createObjectNode();
+        linkObject.put("url", url);
+        textObject.set("link", linkObject);
+        item.set("text", textObject);
+
+        item.put("href", url);
+        item.set("annotations", createDefaultAnnotations());
+        return item;
+    }
+
+    private static ObjectNode createDefaultAnnotations() {
+        var annotations = mapper.createObjectNode();
         annotations.put("bold", false);
         annotations.put("italic", false);
         annotations.put("strikethrough", false);
         annotations.put("underline", false);
         annotations.put("code", false);
         annotations.put("color", "default");
-        richTextItem.set("annotations", annotations);
-
-        richText.add(richTextItem);
-
-        return richText;
+        return annotations;
     }
 
     /**

--- a/src/test/java/io/kestra/plugin/notion/utils/MarkdownConverterTest.java
+++ b/src/test/java/io/kestra/plugin/notion/utils/MarkdownConverterTest.java
@@ -327,6 +327,79 @@ class MarkdownConverterTest {
     }
 
     // =========================
+    // Markdown Link Parsing Tests
+    // =========================
+
+    @Test
+    void testMarkdownLinkInParagraph() {
+        var markdown = "Check out [Kestra](https://kestra.io) for orchestration.";
+        var result = MarkdownConverter.markdownToBlocks(markdown);
+
+        assertThat(result.size(), equalTo(1));
+
+        var richText = result.get(0).path("paragraph").path("rich_text");
+        assertThat(richText.size(), equalTo(3));
+
+        // Plain text before link
+        var before = richText.get(0);
+        assertThat(before.path("text").path("content").asText(), equalTo("Check out "));
+        assertThat(before.path("text").has("link"), equalTo(false));
+        assertThat(before.has("href"), equalTo(false));
+
+        // Link segment
+        var link = richText.get(1);
+        assertThat(link.path("text").path("content").asText(), equalTo("Kestra"));
+        assertThat(link.path("text").path("link").path("url").asText(), equalTo("https://kestra.io"));
+        assertThat(link.path("href").asText(), equalTo("https://kestra.io"));
+
+        // Plain text after link
+        var after = richText.get(2);
+        assertThat(after.path("text").path("content").asText(), equalTo(" for orchestration."));
+        assertThat(after.path("text").has("link"), equalTo(false));
+    }
+
+    @Test
+    void testMarkdownMultipleLinks() {
+        var markdown = "[A](https://a.com) and [B](https://b.com)";
+        var result = MarkdownConverter.markdownToBlocks(markdown);
+
+        var richText = result.get(0).path("paragraph").path("rich_text");
+        assertThat(richText.size(), equalTo(3));
+
+        assertThat(richText.get(0).path("text").path("content").asText(), equalTo("A"));
+        assertThat(richText.get(0).path("href").asText(), equalTo("https://a.com"));
+
+        assertThat(richText.get(1).path("text").path("content").asText(), equalTo(" and "));
+
+        assertThat(richText.get(2).path("text").path("content").asText(), equalTo("B"));
+        assertThat(richText.get(2).path("href").asText(), equalTo("https://b.com"));
+    }
+
+    @Test
+    void testMarkdownLinkOnly() {
+        var markdown = "[Docs](https://docs.example.com)";
+        var result = MarkdownConverter.markdownToBlocks(markdown);
+
+        var richText = result.get(0).path("paragraph").path("rich_text");
+        assertThat(richText.size(), equalTo(1));
+
+        var link = richText.get(0);
+        assertThat(link.path("text").path("content").asText(), equalTo("Docs"));
+        assertThat(link.path("text").path("link").path("url").asText(), equalTo("https://docs.example.com"));
+        assertThat(link.path("href").asText(), equalTo("https://docs.example.com"));
+    }
+
+    @Test
+    void testMarkdownNoLinks() {
+        var markdown = "Plain text without any links.";
+        var result = MarkdownConverter.markdownToBlocks(markdown);
+
+        var richText = result.get(0).path("paragraph").path("rich_text");
+        assertThat(richText.size(), equalTo(1));
+        assertThat(richText.get(0).path("text").path("content").asText(), equalTo("Plain text without any links."));
+    }
+
+    // =========================
     // Edge Cases and Error Handling
     // =========================
 


### PR DESCRIPTION
## Summary
- Parse `[text](url)` markdown link patterns in `createRichTextFromMarkdown`
- Split text into plain and link segments, each as its own Notion rich text item
- Link items include `href` and `text.link.url` fields as required by the Notion API
- Extracted helper methods to reduce duplication: `createPlainRichTextItem`, `createLinkRichTextItem`, `createDefaultAnnotations`
- Added 4 tests covering: link with surrounding text, multiple links, link-only input, and plain text regression

## Test plan
- [x] All 109 existing tests pass
- [x] New tests verify link parsing in various positions
- [x] Plain text (no links) still works as before