### PR TITLE
fix(database): coerce string booleans to Boolean for checkbox properties

### DIFF
--- a/src/main/java/io/kestra/plugin/notion/database/AbstractDatabaseTask.java
+++ b/src/main/java/io/kestra/plugin/notion/database/AbstractDatabaseTask.java
@@ -13,6 +13,9 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @SuperBuilder
@@ -86,5 +89,33 @@ public abstract class AbstractDatabaseTask extends NotionConnection {
     @Override
     protected String getEndpoint() {
         return DATABASES_ENDPOINT;
+    }
+
+    /**
+     * Recursively walks a rendered value and coerces string literals "true"/"false" to their
+     * Boolean equivalents. This is needed because Pebble expressions inside quoted YAML strings
+     * (e.g. {@code checkbox: "{{ myVar }}"}) are always rendered as Strings by Kestra, even when
+     * the underlying value is a boolean. The Notion API strictly expects JSON booleans, not strings,
+     * for checkbox and similar boolean-typed properties.
+     */
+    @SuppressWarnings("unchecked")
+    protected static Object coerceBooleans(Object value) {
+        if (value instanceof Map<?, ?> map) {
+            var result = new LinkedHashMap<String, Object>(map.size());
+            for (var entry : map.entrySet()) {
+                result.put((String) entry.getKey(), coerceBooleans(entry.getValue()));
+            }
+            return result;
+        }
+        if (value instanceof List<?> list) {
+            return list.stream().map(AbstractDatabaseTask::coerceBooleans).toList();
+        }
+        if ("true".equals(value)) {
+            return Boolean.TRUE;
+        }
+        if ("false".equals(value)) {
+            return Boolean.FALSE;
+        }
+        return value;
     }
 }

--- a/src/main/java/io/kestra/plugin/notion/database/CreateItem.java
+++ b/src/main/java/io/kestra/plugin/notion/database/CreateItem.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
@@ -103,9 +104,14 @@ public class CreateItem extends AbstractDatabaseTask implements RunnableTask<Cre
         // Parent: database
         body.put("parent", Map.of("database_id", rDatabaseId));
 
-        // Properties
+        // Properties — coerce string "true"/"false" to Boolean so that Notion checkbox
+        // properties rendered from Pebble expressions are sent as JSON booleans, not strings.
         var rProperties = new HashMap<String, Object>(
-            runContext.render(this.properties).asMap(String.class, Object.class)
+            runContext.render(this.properties).asMap(String.class, Object.class).entrySet().stream()
+                .collect(Collectors.toMap(
+                    Map.Entry::getKey,
+                    e -> coerceBooleans(e.getValue())
+                ))
         );
 
         // Set title property (Notion databases use a "title" typed property, usually named "Name")

--- a/src/main/java/io/kestra/plugin/notion/database/UpdateItem.java
+++ b/src/main/java/io/kestra/plugin/notion/database/UpdateItem.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.notion.database;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
@@ -106,7 +107,13 @@ public class UpdateItem extends AbstractDatabaseTask implements RunnableTask<Upd
 
         var body = new HashMap<String, Object>();
 
-        var rProperties = runContext.render(this.properties).asMap(String.class, Object.class);
+        // Coerce string "true"/"false" to Boolean so that Notion checkbox properties rendered
+        // from Pebble expressions are sent as JSON booleans, not strings.
+        var rProperties = runContext.render(this.properties).asMap(String.class, Object.class).entrySet().stream()
+            .collect(Collectors.toMap(
+                Map.Entry::getKey,
+                e -> coerceBooleans(e.getValue())
+            ));
         if (!rProperties.isEmpty()) {
             body.put("properties", rProperties);
         }

--- a/src/test/java/io/kestra/plugin/notion/database/CreateItemTest.java
+++ b/src/test/java/io/kestra/plugin/notion/database/CreateItemTest.java
@@ -224,6 +224,44 @@ class CreateItemTest {
         assertThat(output.getPageId(), equalTo(PAGE_ID));
     }
 
+    @Test
+    void createItem_withCheckboxAsStringBoolean_sendsJsonBoolean() throws Exception {
+        // Simulates what happens when YAML has `checkbox: "{{ myVar }}"` and Pebble renders
+        // the expression: the surrounding double-quotes force the result to be a String.
+        // The coerceBooleans fix must turn "true"/"false" strings into real JSON booleans
+        // before the request is sent, otherwise Notion rejects the payload.
+        stubCreatePage(PAGE_ID, false);
+
+        var runContext = runContextFactory.of(Map.of());
+
+        // "true" and "false" as Strings, exactly as Pebble would produce them
+        var properties = Map.<String, Object>of(
+            "Done",   Map.<String, Object>of("checkbox", "true"),
+            "Active", Map.<String, Object>of("checkbox", "false")
+        );
+
+        var createItem = CreateItem.builder()
+            .apiToken(Property.ofValue("test-token"))
+            .databaseId(Property.ofValue(DATABASE_ID))
+            .title(Property.ofValue("Checkbox Item"))
+            .properties(Property.ofValue(properties))
+            .build();
+
+        createItem.run(runContext);
+
+        var requests = wireMockServer.findAll(postRequestedFor(urlEqualTo("/v1/pages")));
+        assertThat(requests.size(), equalTo(1));
+        var body = requests.getFirst().getBodyAsString();
+
+        // Must contain bare JSON booleans, not quoted strings
+        assertThat(body, org.hamcrest.Matchers.containsString("\"checkbox\":true"));
+        assertThat(body, org.hamcrest.Matchers.containsString("\"checkbox\":false"));
+
+        // Must NOT contain the string form
+        assertThat(body, org.hamcrest.Matchers.not(org.hamcrest.Matchers.containsString("\"checkbox\":\"true\"")));
+        assertThat(body, org.hamcrest.Matchers.not(org.hamcrest.Matchers.containsString("\"checkbox\":\"false\"")));
+    }
+
     // --- Helper ---
 
     private void stubCreatePage(String pageId, boolean archived) throws Exception {


### PR DESCRIPTION
## Summary

- Pebble expressions inside quoted YAML strings (e.g. `checkbox: "{{ myVar }}"`) are always rendered as `String` by Kestra, even when the underlying value is a boolean
- Notion's API strictly requires JSON booleans for checkbox properties, so `"true"`/`"false"` strings caused API rejections
- Added `coerceBooleans()` helper in `AbstractDatabaseTask` that recursively walks the rendered properties map and converts string literals `"true"`/`"false"` to `Boolean.TRUE`/`Boolean.FALSE` before Jackson serialises the request body
- Applied to both `CreateItem` and `UpdateItem`

## Test plan

- [ ] New unit test `createItem_withCheckboxAsStringBoolean_sendsJsonBoolean` verifies that string `"true"`/`"false"` property values are serialised as bare JSON booleans (not quoted strings) in the HTTP request body
- [ ] All 110 existing tests continue to pass