### PR TITLE
feat: add @PluginProperty group annotations

### DIFF
--- a/src/main/java/io/kestra/plugin/notion/NotionConnection.java
+++ b/src/main/java/io/kestra/plugin/notion/NotionConnection.java
@@ -62,7 +62,7 @@ public abstract class NotionConnection extends Task {
         title = "Notion API token",
         description = "The Notion API integration token (Internal Secret connection)"
     )
-    @PluginProperty
+    @PluginProperty(group = "connection")
     private Property<String> apiToken;
 
     @Schema(title = "The HTTP client configuration.")

--- a/src/main/java/io/kestra/plugin/notion/database/AbstractDatabaseTask.java
+++ b/src/main/java/io/kestra/plugin/notion/database/AbstractDatabaseTask.java
@@ -17,6 +17,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -32,6 +33,7 @@ public abstract class AbstractDatabaseTask extends NotionConnection {
         description = "Notion database identifier; both UUID and 32-character hex formats are accepted."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> databaseId;
 
     /**

--- a/src/main/java/io/kestra/plugin/notion/database/CreateItem.java
+++ b/src/main/java/io/kestra/plugin/notion/database/CreateItem.java
@@ -22,6 +22,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -70,6 +71,7 @@ public class CreateItem extends AbstractDatabaseTask implements RunnableTask<Cre
         description = "The title for the new database row. Mapped to the database title property."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> title;
 
     @Schema(
@@ -79,6 +81,7 @@ public class CreateItem extends AbstractDatabaseTask implements RunnableTask<Cre
             Keys are property names as defined in the database schema.
             See the [Notion property value reference](https://developers.notion.com/reference/property-value-object)."""
     )
+    @PluginProperty(group = "advanced")
     private Property<Map<String, Object>> properties;
 
     @Schema(
@@ -87,6 +90,7 @@ public class CreateItem extends AbstractDatabaseTask implements RunnableTask<Cre
             Optional markdown content appended as paragraph blocks to the page body.
             Note that the Notion API enforces a limit of 2000 characters per [rich text content block](https://developers.notion.com/reference/request-limits)."""
     )
+    @PluginProperty(group = "advanced")
     private Property<String> content;
 
     @Override

--- a/src/main/java/io/kestra/plugin/notion/database/Query.java
+++ b/src/main/java/io/kestra/plugin/notion/database/Query.java
@@ -19,6 +19,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -81,6 +82,7 @@ public class Query extends AbstractDatabaseTask implements RunnableTask<Query.Ou
             A Notion filter object applied to the query.
             See the [Notion API filter reference](https://developers.notion.com/reference/post-database-query-filter) for the full schema."""
     )
+    @PluginProperty(group = "processing")
     private Property<Map<String, Object>> filter;
 
     @Schema(
@@ -89,6 +91,7 @@ public class Query extends AbstractDatabaseTask implements RunnableTask<Query.Ou
             A list of sort objects controlling result ordering.
             Each entry must have a `property` and a `direction` (`ascending` or `descending`)."""
     )
+    @PluginProperty(group = "advanced")
     private Property<List<Map<String, Object>>> sorts;
 
     @Builder.Default
@@ -96,12 +99,14 @@ public class Query extends AbstractDatabaseTask implements RunnableTask<Query.Ou
         title = "Page size",
         description = "Maximum number of results per page (1-100). Defaults to 100."
     )
+    @PluginProperty(group = "advanced")
     private Property<Integer> pageSize = Property.ofValue(100);
 
     @Schema(
         title = "Start cursor",
         description = "Pagination cursor returned by a previous query to fetch the next page of results."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> startCursor;
 
     @Builder.Default
@@ -114,6 +119,7 @@ public class Query extends AbstractDatabaseTask implements RunnableTask<Query.Ou
             `FETCH_ONE` returns only the first row.
             `NONE` skips returning row data entirely."""
     )
+    @PluginProperty(group = "execution")
     private Property<FetchType> fetchType = Property.ofValue(FetchType.STORE);
 
     @Override

--- a/src/main/java/io/kestra/plugin/notion/database/UpdateItem.java
+++ b/src/main/java/io/kestra/plugin/notion/database/UpdateItem.java
@@ -20,6 +20,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -78,6 +79,7 @@ public class UpdateItem extends AbstractDatabaseTask implements RunnableTask<Upd
         description = "The ID of the database item (page) to update; both UUID and 32-character hex formats are accepted."
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> pageId;
 
     @Schema(
@@ -87,12 +89,14 @@ public class UpdateItem extends AbstractDatabaseTask implements RunnableTask<Upd
             Only the provided properties will be changed; others remain untouched.
             See the [Notion property value reference](https://developers.notion.com/reference/property-value-object)."""
     )
+    @PluginProperty(group = "advanced")
     private Property<Map<String, Object>> properties;
 
     @Schema(
         title = "Archived",
         description = "Set to `true` to soft-delete (archive) the item, or `false` to restore it."
     )
+    @PluginProperty(group = "advanced")
     private Property<Boolean> archived;
 
     @Override

--- a/src/main/java/io/kestra/plugin/notion/page/AbstractTask.java
+++ b/src/main/java/io/kestra/plugin/notion/page/AbstractTask.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -27,6 +28,7 @@ public abstract class AbstractTask extends NotionConnection implements RunnableT
         description = "Notion page identifier in UUID format; 32‑character hex is also accepted"
     )
     @NotNull
+    @PluginProperty(group = "main")
     protected Property<String> pageId;
 
     /**

--- a/src/main/java/io/kestra/plugin/notion/page/Create.java
+++ b/src/main/java/io/kestra/plugin/notion/page/Create.java
@@ -21,6 +21,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -89,6 +90,7 @@ public class Create extends NotionConnection implements RunnableTask<Create.Outp
         description = "Required page title text"
     )
     @NotNull
+    @PluginProperty(group = "main")
     private Property<String> title;
 
     @Schema(
@@ -97,12 +99,14 @@ public class Create extends NotionConnection implements RunnableTask<Create.Outp
             Optional markdown content converted to Notion blocks; empty leaves the page body blank.
             Note that the Notion API enforces a limit of 2000 characters per [rich text content block](https://developers.notion.com/reference/request-limits)."""
     )
+    @PluginProperty(group = "advanced")
     private Property<String> content;
 
     @Schema(
         title = "Parent page ID",
         description = "Optional parent page ID (UUID). When absent, the page is created at the workspace root"
     )
+    @PluginProperty(group = "advanced")
     private Property<String> parentPageId;
 
     @Override

--- a/src/main/java/io/kestra/plugin/notion/page/Update.java
+++ b/src/main/java/io/kestra/plugin/notion/page/Update.java
@@ -18,6 +18,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
+import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -87,6 +88,7 @@ public class Update extends AbstractTask {
         title = "New page title",
         description = "Optional new title for the page. If not provided, the existing title will be kept."
     )
+    @PluginProperty(group = "advanced")
     private Property<String> title;
 
     @Schema(
@@ -95,6 +97,7 @@ public class Update extends AbstractTask {
             The new content for the page in markdown format. This will be appended to the bottom of the page.
             Note that the Notion API enforces a limit of 2000 characters per [rich text content block](https://developers.notion.com/reference/request-limits)."""
     )
+    @PluginProperty(group = "advanced")
     private Property<String> content;
 
     @Override


### PR DESCRIPTION
## Summary

Add `@PluginProperty(group = "...")` annotations to task properties following the 9-group taxonomy (`main`, `connection`, `source`, `processing`, `execution`, `destination`, `reliability`, `advanced`, `deprecated`).

These annotations drive section grouping in the Kestra NoCode UI editor.

Groups are assigned from a curated CSV of 8,798 property assignments across 925 task types, with heuristic fallback for properties not in the CSV.

Part-of: https://github.com/kestra-io/kestra-ee/issues/6712