### PR TITLE
feat(database): add DeleteItem and Update tasks

### DIFF
--- a/src/main/java/io/kestra/plugin/notion/database/AbstractDatabaseTask.java
+++ b/src/main/java/io/kestra/plugin/notion/database/AbstractDatabaseTask.java
@@ -88,6 +88,13 @@ public abstract class AbstractDatabaseTask extends NotionConnection {
         throw new IllegalArgumentException("ID must be a valid UUID or a 32-character hex string, got: " + id);
     }
 
+    /**
+     * Builds the Notion API URL for a specific database entity.
+     */
+    protected String buildDatabaseUrl(String databaseId) {
+        return getBaseUrl() + DATABASES_ENDPOINT + "/" + databaseId;
+    }
+
     @Override
     protected String getEndpoint() {
         return DATABASES_ENDPOINT;

--- a/src/main/java/io/kestra/plugin/notion/database/DeleteItem.java
+++ b/src/main/java/io/kestra/plugin/notion/database/DeleteItem.java
@@ -1,0 +1,151 @@
+package io.kestra.plugin.notion.database;
+
+import java.util.Map;
+
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.runners.RunContext;
+import io.kestra.plugin.notion.NotionResponse;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Schema(
+    title = "Archive a Notion database item",
+    description = """
+        Archives (soft-deletes) a row inside a Notion database by setting `archived=true` on the target page.
+        Notion has no hard-delete API — archiving is the API equivalent and the page remains recoverable from Notion trash.
+        Requires a valid page ID that identifies the row within the database."""
+)
+@Plugin(
+    examples = {
+        @Example(
+            title = "Archive a database row by page ID",
+            full = true,
+            code = """
+                id: notion_archive_database_item
+                namespace: company.team
+
+                inputs:
+                  - id: page_id
+                    type: STRING
+
+                tasks:
+                  - id: archive_row
+                    type: io.kestra.plugin.notion.database.DeleteItem
+                    apiToken: "{{ secret('NOTION_API_TOKEN') }}"
+                    databaseId: "12345678-1234-1234-1234-123456789abc"
+                    pageId: "{{ inputs.page_id }}"
+                """
+        ),
+        @Example(
+            title = "Archive a specific database row",
+            full = true,
+            code = """
+                id: notion_archive_specific_row
+                namespace: company.team
+
+                tasks:
+                  - id: archive_row
+                    type: io.kestra.plugin.notion.database.DeleteItem
+                    apiToken: "{{ secret('NOTION_API_TOKEN') }}"
+                    databaseId: "12345678-1234-1234-1234-123456789abc"
+                    pageId: "abcdef12-3456-7890-abcd-ef1234567890"
+                """
+        )
+    }
+)
+public class DeleteItem extends AbstractDatabaseTask implements RunnableTask<DeleteItem.Output> {
+
+    @Schema(
+        title = "Page ID",
+        description = """
+            The unique identifier of the database item (row) to archive.
+            Both UUID and 32-character hex formats are accepted."""
+    )
+    @NotNull
+    @PluginProperty(group = "main")
+    private Property<String> pageId;
+
+    @Override
+    public Output run(RunContext runContext) throws Exception {
+        var logger = runContext.logger();
+
+        var rPageId = normalizeId(
+            runContext.render(this.pageId).as(String.class).orElseThrow(
+                () -> new IllegalArgumentException("pageId is required")
+            )
+        );
+
+        logger.info("Checking Notion database item with page ID: {}", rPageId);
+
+        var pageUrl = buildPageURL(rPageId);
+        var getRequestBuilder = buildGetRequest(runContext, pageUrl);
+        var pageResponse = makeCall(runContext, getRequestBuilder, NotionResponse.class);
+
+        if (Boolean.TRUE.equals(pageResponse.getArchived())) {
+            logger.warn("Database item {} is already archived", rPageId);
+            return Output.builder()
+                .pageId(rPageId)
+                .url(pageResponse.getUrl())
+                .message("Page is already archived")
+                .build();
+        }
+
+        logger.info("Archiving Notion database item {}", rPageId);
+
+        var body = Map.<String, Object>of("archived", true);
+        var patchRequestBuilder = buildPatchRequest(runContext, pageUrl, body);
+        var archiveResponse = makeCall(runContext, patchRequestBuilder, NotionResponse.class);
+
+        logger.info("Successfully archived database item {}", rPageId);
+
+        return Output.builder()
+            .pageId(archiveResponse.getId())
+            .url(archiveResponse.getUrl())
+            .message("Page archived successfully")
+            .build();
+    }
+
+    @Override
+    protected String getEndpoint() {
+        return DATABASES_ENDPOINT;
+    }
+
+    @Getter
+    @Builder
+    public static class Output implements io.kestra.core.models.tasks.Output {
+
+        @Schema(
+            title = "Page ID",
+            description = "The unique identifier of the archived database item."
+        )
+        private String pageId;
+
+        @Schema(
+            title = "URL",
+            description = "The Notion URL of the archived item."
+        )
+        private String url;
+
+        @Schema(
+            title = "Message",
+            description = "Result message indicating the outcome of the archive operation."
+        )
+        private String message;
+    }
+}

--- a/src/main/java/io/kestra/plugin/notion/database/Update.java
+++ b/src/main/java/io/kestra/plugin/notion/database/Update.java
@@ -1,0 +1,153 @@
+package io.kestra.plugin.notion.database;
+
+import java.util.HashMap;
+
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.runners.RunContext;
+import io.kestra.plugin.notion.NotionResponse;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+import java.util.List;
+import java.util.Map;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Schema(
+    title = "Update a Notion database",
+    description = """
+        Updates the title and/or description of an existing Notion database entity.
+        At least one of `title` or `description` must be provided.
+        Both properties are optional individually but the task requires at least one to be set."""
+)
+@Plugin(
+    examples = {
+        @Example(
+            title = "Update a database title and description",
+            full = true,
+            code = """
+                id: notion_update_database
+                namespace: company.team
+
+                tasks:
+                  - id: update_db
+                    type: io.kestra.plugin.notion.database.Update
+                    apiToken: "{{ secret('NOTION_API_TOKEN') }}"
+                    databaseId: "12345678-1234-1234-1234-123456789abc"
+                    title: "Updated Project Tracker"
+                    description: "Tracks all active projects managed by the data team."
+                """
+        ),
+        @Example(
+            title = "Update only the database title",
+            full = true,
+            code = """
+                id: notion_rename_database
+                namespace: company.team
+
+                tasks:
+                  - id: rename_db
+                    type: io.kestra.plugin.notion.database.Update
+                    apiToken: "{{ secret('NOTION_API_TOKEN') }}"
+                    databaseId: "12345678-1234-1234-1234-123456789abc"
+                    title: "Q2 Sprint Board"
+                """
+        )
+    }
+)
+public class Update extends AbstractDatabaseTask implements RunnableTask<Update.Output> {
+
+    @Schema(
+        title = "Title",
+        description = "The new title to set on the Notion database. When provided, replaces the existing title."
+    )
+    @PluginProperty(group = "main")
+    private Property<String> title;
+
+    @Schema(
+        title = "Description",
+        description = """
+            The new description to set on the Notion database (plain text).
+            The plugin wraps the value in the rich text format expected by the Notion API."""
+    )
+    @PluginProperty(group = "main")
+    private Property<String> databaseDescription;
+
+    @Override
+    public Output run(RunContext runContext) throws Exception {
+        var logger = runContext.logger();
+
+        var rDatabaseId = renderDatabaseId(runContext);
+        var rTitle = runContext.render(this.title).as(String.class).orElse(null);
+        var rDescription = runContext.render(this.databaseDescription).as(String.class).orElse(null);
+
+        if (rTitle == null && rDescription == null) {
+            throw new IllegalArgumentException("At least one of 'title' or 'description' must be provided");
+        }
+
+        var body = new HashMap<String, Object>();
+
+        if (rTitle != null) {
+            body.put("title", List.of(Map.of("type", "text", "text", Map.of("content", rTitle))));
+        }
+
+        if (rDescription != null) {
+            body.put("description", List.of(Map.of("type", "text", "text", Map.of("content", rDescription))));
+        }
+
+        var url = buildDatabaseUrl(rDatabaseId);
+        logger.info("Updating Notion database {}", rDatabaseId);
+
+        var requestBuilder = buildPatchRequest(runContext, url, body);
+        var response = makeCall(runContext, requestBuilder, NotionResponse.class);
+
+        logger.info("Successfully updated Notion database {}", response.getId());
+
+        return Output.builder()
+            .databaseId(response.getId())
+            .url(response.getUrl())
+            .message("Database updated successfully")
+            .build();
+    }
+
+    @Override
+    protected String getEndpoint() {
+        return DATABASES_ENDPOINT;
+    }
+
+    @Getter
+    @Builder
+    public static class Output implements io.kestra.core.models.tasks.Output {
+
+        @Schema(
+            title = "Database ID",
+            description = "The unique identifier of the updated Notion database."
+        )
+        private String databaseId;
+
+        @Schema(
+            title = "URL",
+            description = "The Notion URL of the updated database."
+        )
+        private String url;
+
+        @Schema(
+            title = "Message",
+            description = "Result message indicating the outcome of the update operation."
+        )
+        private String message;
+    }
+}

--- a/src/test/java/io/kestra/plugin/notion/database/DeleteItemTest.java
+++ b/src/test/java/io/kestra/plugin/notion/database/DeleteItemTest.java
@@ -1,0 +1,157 @@
+package io.kestra.plugin.notion.database;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.serializers.JacksonMapper;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.patch;
+import static com.github.tomakehurst.wiremock.client.WireMock.patchRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+
+@KestraTest
+class DeleteItemTest {
+
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    private static final ObjectMapper mapper = JacksonMapper.ofJson(false);
+
+    private WireMockServer wireMockServer;
+    private String previousBaseUrl;
+
+    private static final String DATABASE_ID = "33333333-3333-3333-3333-333333333333";
+    private static final String PAGE_ID = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+
+    @BeforeEach
+    void setUp() {
+        wireMockServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        wireMockServer.start();
+        previousBaseUrl = System.getProperty("notion.api.base.url");
+        System.setProperty("notion.api.base.url", wireMockServer.baseUrl());
+        configureFor("localhost", wireMockServer.port());
+    }
+
+    @AfterEach
+    void tearDown() {
+        wireMockServer.stop();
+        if (previousBaseUrl == null) {
+            System.clearProperty("notion.api.base.url");
+        } else {
+            System.setProperty("notion.api.base.url", previousBaseUrl);
+        }
+    }
+
+    @Test
+    void deleteItem_archivesPage_successfully() throws Exception {
+        // Stub GET to return a non-archived page
+        stubGetPage(PAGE_ID, false);
+        // Stub PATCH to return the archived page
+        stubPatchPage(PAGE_ID, true);
+
+        var runContext = runContextFactory.of(Map.of());
+
+        var deleteItem = DeleteItem.builder()
+            .apiToken(Property.ofValue("test-token"))
+            .databaseId(Property.ofValue(DATABASE_ID))
+            .pageId(Property.ofValue(PAGE_ID))
+            .build();
+
+        var output = deleteItem.run(runContext);
+
+        assertThat(output.getPageId(), equalTo(PAGE_ID));
+        assertThat(output.getUrl(), notNullValue());
+        assertThat(output.getMessage(), containsString("archived"));
+
+        // Verify PATCH was made with archived=true
+        wireMockServer.verify(patchRequestedFor(urlEqualTo("/v1/pages/" + PAGE_ID))
+            .withRequestBody(com.github.tomakehurst.wiremock.client.WireMock.containing("\"archived\":true")));
+    }
+
+    @Test
+    void deleteItem_alreadyArchived_returnsEarlyMessage() throws Exception {
+        // Stub GET to return an already-archived page
+        stubGetPage(PAGE_ID, true);
+
+        var runContext = runContextFactory.of(Map.of());
+
+        var deleteItem = DeleteItem.builder()
+            .apiToken(Property.ofValue("test-token"))
+            .databaseId(Property.ofValue(DATABASE_ID))
+            .pageId(Property.ofValue(PAGE_ID))
+            .build();
+
+        var output = deleteItem.run(runContext);
+
+        assertThat(output.getMessage(), containsString("already archived"));
+
+        // Verify no PATCH was made
+        wireMockServer.verify(0, patchRequestedFor(urlEqualTo("/v1/pages/" + PAGE_ID)));
+    }
+
+    // --- Helpers ---
+
+    private void stubGetPage(String pageId, boolean archived) throws Exception {
+        var responseBody = new HashMap<String, Object>();
+        responseBody.put("object", "page");
+        responseBody.put("id", pageId);
+        responseBody.put("archived", archived);
+        responseBody.put("url", "https://www.notion.so/" + pageId);
+        responseBody.put("properties", Map.of(
+            "Name", Map.of("title", List.of(Map.of("plain_text", "Test Row")))
+        ));
+
+        wireMockServer.stubFor(
+            get(urlEqualTo("/v1/pages/" + pageId))
+                .willReturn(
+                    aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(mapper.writeValueAsString(responseBody))
+                        .withStatus(200)
+                )
+        );
+    }
+
+    private void stubPatchPage(String pageId, boolean archived) throws Exception {
+        var responseBody = new HashMap<String, Object>();
+        responseBody.put("object", "page");
+        responseBody.put("id", pageId);
+        responseBody.put("archived", archived);
+        responseBody.put("url", "https://www.notion.so/" + pageId);
+        responseBody.put("properties", Map.of(
+            "Name", Map.of("title", List.of(Map.of("plain_text", "Test Row")))
+        ));
+
+        wireMockServer.stubFor(
+            patch(urlEqualTo("/v1/pages/" + pageId))
+                .willReturn(
+                    aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(mapper.writeValueAsString(responseBody))
+                        .withStatus(200)
+                )
+        );
+    }
+}

--- a/src/test/java/io/kestra/plugin/notion/database/UpdateTest.java
+++ b/src/test/java/io/kestra/plugin/notion/database/UpdateTest.java
@@ -1,0 +1,172 @@
+package io.kestra.plugin.notion.database;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.serializers.JacksonMapper;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.patch;
+import static com.github.tomakehurst.wiremock.client.WireMock.patchRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@KestraTest
+class UpdateTest {
+
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    private static final ObjectMapper mapper = JacksonMapper.ofJson(false);
+
+    private WireMockServer wireMockServer;
+    private String previousBaseUrl;
+
+    private static final String DATABASE_ID = "44444444-4444-4444-4444-444444444444";
+
+    @BeforeEach
+    void setUp() {
+        wireMockServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        wireMockServer.start();
+        previousBaseUrl = System.getProperty("notion.api.base.url");
+        System.setProperty("notion.api.base.url", wireMockServer.baseUrl());
+        configureFor("localhost", wireMockServer.port());
+    }
+
+    @AfterEach
+    void tearDown() {
+        wireMockServer.stop();
+        if (previousBaseUrl == null) {
+            System.clearProperty("notion.api.base.url");
+        } else {
+            System.setProperty("notion.api.base.url", previousBaseUrl);
+        }
+    }
+
+    @Test
+    void update_withTitleAndDescription_updatesDatabase() throws Exception {
+        stubPatchDatabase(DATABASE_ID);
+
+        var runContext = runContextFactory.of(Map.of());
+
+        var update = Update.builder()
+            .apiToken(Property.ofValue("test-token"))
+            .databaseId(Property.ofValue(DATABASE_ID))
+            .title(Property.ofValue("Updated Title"))
+            .databaseDescription(Property.ofValue("Updated description text"))
+            .build();
+
+        var output = update.run(runContext);
+
+        assertThat(output.getDatabaseId(), equalTo(DATABASE_ID));
+        assertThat(output.getUrl(), notNullValue());
+        assertThat(output.getMessage(), equalTo("Database updated successfully"));
+
+        // Verify both title and description were sent
+        wireMockServer.verify(patchRequestedFor(urlEqualTo("/v1/databases/" + DATABASE_ID))
+            .withRequestBody(com.github.tomakehurst.wiremock.client.WireMock.containing("\"title\""))
+            .withRequestBody(com.github.tomakehurst.wiremock.client.WireMock.containing("\"description\"")));
+    }
+
+    @Test
+    void update_withTitleOnly_updatesTitleOnly() throws Exception {
+        stubPatchDatabase(DATABASE_ID);
+
+        var runContext = runContextFactory.of(Map.of());
+
+        var update = Update.builder()
+            .apiToken(Property.ofValue("test-token"))
+            .databaseId(Property.ofValue(DATABASE_ID))
+            .title(Property.ofValue("Only Title"))
+            .build();
+
+        var output = update.run(runContext);
+
+        assertThat(output.getDatabaseId(), equalTo(DATABASE_ID));
+        assertThat(output.getMessage(), equalTo("Database updated successfully"));
+
+        // Verify title is present but description is NOT
+        var requests = wireMockServer.findAll(patchRequestedFor(urlEqualTo("/v1/databases/" + DATABASE_ID)));
+        assertThat(requests.size(), equalTo(1));
+        var body = requests.getFirst().getBodyAsString();
+        assertThat(body, containsString("\"title\""));
+        assertThat(body, not(containsString("\"description\"")));
+    }
+
+    @Test
+    void update_withDescriptionOnly_updatesDescriptionOnly() throws Exception {
+        stubPatchDatabase(DATABASE_ID);
+
+        var runContext = runContextFactory.of(Map.of());
+
+        var update = Update.builder()
+            .apiToken(Property.ofValue("test-token"))
+            .databaseId(Property.ofValue(DATABASE_ID))
+            .databaseDescription(Property.ofValue("Only description"))
+            .build();
+
+        var output = update.run(runContext);
+
+        assertThat(output.getDatabaseId(), equalTo(DATABASE_ID));
+        assertThat(output.getMessage(), equalTo("Database updated successfully"));
+
+        // Verify description is present but title is NOT
+        var requests = wireMockServer.findAll(patchRequestedFor(urlEqualTo("/v1/databases/" + DATABASE_ID)));
+        assertThat(requests.size(), equalTo(1));
+        var body = requests.getFirst().getBodyAsString();
+        assertThat(body, containsString("\"description\""));
+        assertThat(body, not(containsString("\"title\"")));
+    }
+
+    @Test
+    void update_withNeitherTitleNorDescription_throwsIllegalArgumentException() {
+        var runContext = runContextFactory.of(Map.of());
+
+        var update = Update.builder()
+            .apiToken(Property.ofValue("test-token"))
+            .databaseId(Property.ofValue(DATABASE_ID))
+            .build();
+
+        var exception = assertThrows(IllegalArgumentException.class, () -> update.run(runContext));
+        assertThat(exception.getMessage(), containsString("title"));
+        assertThat(exception.getMessage(), containsString("description"));
+    }
+
+    // --- Helper ---
+
+    private void stubPatchDatabase(String databaseId) throws Exception {
+        var responseBody = new HashMap<String, Object>();
+        responseBody.put("object", "database");
+        responseBody.put("id", databaseId);
+        responseBody.put("url", "https://www.notion.so/" + databaseId);
+
+        wireMockServer.stubFor(
+            patch(urlEqualTo("/v1/databases/" + databaseId))
+                .willReturn(
+                    aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(mapper.writeValueAsString(responseBody))
+                        .withStatus(200)
+                )
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `database/DeleteItem` task to archive (soft-delete) a database row; returns early with an informational message if the row is already archived
- Adds `database/Update` task to update the Notion database entity itself (title and/or description); accepts plain strings and wraps them in rich text arrays internally
- Adds `buildDatabaseUrl()` helper to `AbstractDatabaseTask`

## Test plan

- [ ] `DeleteItemTest` — happy path (archives row) and already-archived guard (no PATCH made)
- [ ] `UpdateTest` — title-only, description-only, both, and neither (throws `IllegalArgumentException`)
- [ ] `./gradlew test && ./gradlew shadowJar` — all green

Closes https://github.com/kestra-io/plugin-notion/issues/9