### PR TITLE
fix(plugin-notion): align @PluginSubGroup titles with metadata YAML

### DIFF
--- a/src/main/java/io/kestra/plugin/notion/database/package-info.java
+++ b/src/main/java/io/kestra/plugin/notion/database/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-    title = "Notion Database",
+    title = "Notion Databases",
     description = "This sub-group of plugins contains tasks for querying and managing items in Notion databases.",
     categories = {
         PluginSubGroup.PluginCategory.BUSINESS

--- a/src/main/java/io/kestra/plugin/notion/page/package-info.java
+++ b/src/main/java/io/kestra/plugin/notion/page/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-    title = "Notion",
+    title = "Notion Pages",
     description = "This sub-group of plugins contains tasks for using Notion API to create, read, update, and archive pages with markdown content.", categories = {
         PluginSubGroup.PluginCategory.BUSINESS
     }


### PR DESCRIPTION
## Summary

- Updates `@PluginSubGroup(title = ...)` in `package-info.java` files to match the `title` field in the corresponding subgroup metadata YAML files
- Eliminates duplicate/empty subgroup URLs on kestra.io caused by the annotation falling back to the package name when no title is set, while metadata uses a different slug

## Test plan

- [ ] Verify kestra.io subgroup pages no longer show empty duplicate routes after merge