### PR TITLE
feat(page): add UpdateTrigger to react to Notion page updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ Infrastructure dependencies (Docker Compose services):
 - `io.kestra.plugin.notion.page.Create`
 - `io.kestra.plugin.notion.page.Read`
 - `io.kestra.plugin.notion.page.Update`
+- `io.kestra.plugin.notion.page.UpdateTrigger` — polling trigger that fires when Notion pages are updated
 
 ### Project Structure
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,7 @@
 version=1.5.3-SNAPSHOT
 kestraVersion=1.3.13
+
+org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.priority=low

--- a/src/main/java/io/kestra/plugin/notion/NotionConnection.java
+++ b/src/main/java/io/kestra/plugin/notion/NotionConnection.java
@@ -46,7 +46,7 @@ public abstract class NotionConnection extends Task {
     /**
      * Gets the base URL for Notion API, allowing override for testing
      */
-    protected static String getBaseUrl() {
+    public static String getBaseUrl() {
         String overrideUrl = System.getProperty("notion.api.base.url");
         return overrideUrl != null ? overrideUrl : NOTION_API_URL;
     }

--- a/src/main/java/io/kestra/plugin/notion/page/UpdateTrigger.java
+++ b/src/main/java/io/kestra/plugin/notion/page/UpdateTrigger.java
@@ -4,6 +4,7 @@ import java.net.URI;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -178,8 +179,10 @@ public class UpdateTrigger extends AbstractTrigger implements PollingTriggerInte
         var rQuery = runContext.render(query).as(String.class).orElse(null);
         var rParentPageId = runContext.render(parentPageId).as(String.class).orElse(null);
 
-        // The watermark is the last trigger evaluation time. Pages edited strictly after this are new.
-        Instant watermark = context.getDate().toInstant();
+        // Truncate to minutes: Notion's last_edited_time has minute-level precision (seconds are always 0).
+        // Using the raw sub-second evaluation timestamp as watermark would silently miss pages edited
+        // within the same minute as the previous poll.
+        Instant watermark = context.getDate().toInstant().truncatedTo(ChronoUnit.MINUTES);
 
         logger.debug("Polling Notion for pages updated after {}", watermark);
 
@@ -223,7 +226,8 @@ public class UpdateTrigger extends AbstractTrigger implements PollingTriggerInte
                 var lastEditedTime = Instant.parse(lastEditedRaw);
 
                 // Results are sorted descending by last_edited_time; early-exit once we reach older pages.
-                if (!lastEditedTime.isAfter(watermark)) {
+                // Use isBefore (strict <) so pages at exactly the watermark minute are included.
+                if (lastEditedTime.isBefore(watermark)) {
                     return result;
                 }
 

--- a/src/main/java/io/kestra/plugin/notion/page/UpdateTrigger.java
+++ b/src/main/java/io/kestra/plugin/notion/page/UpdateTrigger.java
@@ -1,0 +1,363 @@
+package io.kestra.plugin.notion.page;
+
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.kestra.core.http.HttpRequest;
+import io.kestra.core.http.client.HttpClient;
+import io.kestra.core.http.client.configurations.HttpConfiguration;
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.conditions.ConditionContext;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.models.triggers.AbstractTrigger;
+import io.kestra.core.models.triggers.PollingTriggerInterface;
+import io.kestra.core.models.triggers.TriggerContext;
+import io.kestra.core.models.triggers.TriggerOutput;
+import io.kestra.core.models.triggers.TriggerService;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.serializers.JacksonMapper;
+import io.kestra.plugin.notion.NotionConnection;
+import io.kestra.plugin.notion.NotionResponse;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Schema(
+    title = "React to Notion page updates.",
+    description = """
+        Polls the Notion Search API at the configured interval.
+        On each evaluation it collects all pages whose `last_edited_time` is strictly greater than
+        the watermark (taken from `TriggerContext.date`, which is the last evaluation timestamp).
+        When at least one updated page is found, a flow execution is fired; otherwise the trigger
+        is silent and waits for the next interval.
+
+        Optional `query` narrows the search server-side using Notion full-text search.
+        Optional `parentPageId` retains only pages that are direct children of that parent page
+        (client-side filter, because the Notion Search API does not expose a server-side parent filter)."""
+)
+@Plugin(
+    examples = {
+        @Example(
+            title = "Trigger on any Notion page update every 5 minutes",
+            full = true,
+            code = """
+                id: notion_page_updated
+                namespace: company.team
+
+                tasks:
+                  - id: log_updated_pages
+                    type: io.kestra.plugin.core.log.Log
+                    message: "Updated pages: {{ trigger.updatedPages }}"
+
+                triggers:
+                  - id: watch_pages
+                    type: io.kestra.plugin.notion.page.UpdateTrigger
+                    apiToken: "{{ secret('NOTION_API_TOKEN') }}"
+                    interval: PT5M
+                """
+        ),
+        @Example(
+            title = "Trigger only for pages matching a keyword search",
+            full = true,
+            code = """
+                id: notion_keyword_page_updated
+                namespace: company.team
+
+                tasks:
+                  - id: process_pages
+                    type: io.kestra.plugin.core.log.Log
+                    message: "Sprint pages updated: {{ trigger.updatedPages }}"
+
+                triggers:
+                  - id: watch_sprint_pages
+                    type: io.kestra.plugin.notion.page.UpdateTrigger
+                    apiToken: "{{ secret('NOTION_API_TOKEN') }}"
+                    query: "Sprint"
+                    interval: PT10M
+                """
+        ),
+        @Example(
+            title = "Trigger only for pages under a specific parent page",
+            full = true,
+            code = """
+                id: notion_child_page_updated
+                namespace: company.team
+
+                tasks:
+                  - id: handle_update
+                    type: io.kestra.plugin.core.log.Log
+                    message: "Child page updated: {{ trigger.updatedPages }}"
+
+                triggers:
+                  - id: watch_child_pages
+                    type: io.kestra.plugin.notion.page.UpdateTrigger
+                    apiToken: "{{ secret('NOTION_API_TOKEN') }}"
+                    parentPageId: "12345678-1234-1234-1234-123456789abc"
+                    interval: PT15M
+                """
+        )
+    }
+)
+public class UpdateTrigger extends AbstractTrigger implements PollingTriggerInterface, TriggerOutput<UpdateTrigger.Output> {
+
+    private static final ObjectMapper MAPPER = JacksonMapper.ofJson(false);
+    private static final int PAGE_SIZE = 100;
+
+    @Builder.Default
+    @Schema(
+        title = "Interval between polls.",
+        description = "ISO 8601 duration. A minimum of PT30S is recommended to avoid overloading the Notion API."
+    )
+    @PluginProperty(group = "execution")
+    @NotNull
+    private Duration interval = Duration.ofMinutes(5);
+
+    @Schema(
+        title = "Notion API token.",
+        description = "The Notion internal integration token used to authenticate API requests."
+    )
+    @PluginProperty(group = "connection", secret = true)
+    @NotNull
+    private Property<String> apiToken;
+
+    @Schema(title = "HTTP client configuration.")
+    @PluginProperty(group = "connection")
+    private HttpConfiguration options;
+
+    @Schema(
+        title = "Full-text search query.",
+        description = "Optional text passed as the `query` field of the Notion Search API request. Narrows results server-side to pages whose title or content matches the search terms."
+    )
+    @PluginProperty(group = "processing")
+    private Property<String> query;
+
+    @Schema(
+        title = "Parent page ID filter.",
+        description = """
+            Optional Notion page UUID. When set, only pages whose direct parent is this page are reported.
+            This is a client-side filter applied after the API response because the Notion Search API
+            does not expose a server-side parent filter."""
+    )
+    @PluginProperty(group = "processing")
+    private Property<String> parentPageId;
+
+    @Override
+    public Optional<Execution> evaluate(ConditionContext conditionContext, TriggerContext context) throws Exception {
+        var runContext = conditionContext.getRunContext();
+        var logger = runContext.logger();
+
+        var rApiToken = runContext.render(apiToken).as(String.class).orElseThrow(
+            () -> new IllegalArgumentException("apiToken is required")
+        );
+        var rQuery = runContext.render(query).as(String.class).orElse(null);
+        var rParentPageId = runContext.render(parentPageId).as(String.class).orElse(null);
+
+        // The watermark is the last trigger evaluation time. Pages edited strictly after this are new.
+        Instant watermark = context.getDate().toInstant();
+
+        logger.debug("Polling Notion for pages updated after {}", watermark);
+
+        var updatedPages = collectUpdatedPages(runContext, rApiToken, rQuery, rParentPageId, watermark);
+
+        if (updatedPages.isEmpty()) {
+            return Optional.empty();
+        }
+
+        logger.info("Found {} updated Notion page(s) since {}", updatedPages.size(), watermark);
+
+        var output = Output.builder().updatedPages(updatedPages).build();
+        return Optional.of(TriggerService.generateExecution(this, conditionContext, context, output));
+    }
+
+    private List<PageInfo> collectUpdatedPages(
+        RunContext runContext,
+        String rApiToken,
+        String rQuery,
+        String rParentPageId,
+        Instant watermark
+    ) throws Exception {
+        var result = new ArrayList<PageInfo>();
+        String cursor = null;
+        boolean hasMore = true;
+
+        while (hasMore) {
+            var body = buildSearchBody(rQuery, cursor);
+            var response = callSearchApi(runContext, rApiToken, body);
+
+            var results = response.getChildren();
+            if (results == null || results.isEmpty()) {
+                break;
+            }
+
+            for (var item : results) {
+                var lastEditedRaw = (String) item.get("last_edited_time");
+                if (lastEditedRaw == null) {
+                    continue;
+                }
+                var lastEditedTime = Instant.parse(lastEditedRaw);
+
+                // Results are sorted descending by last_edited_time; early-exit once we reach older pages.
+                if (!lastEditedTime.isAfter(watermark)) {
+                    return result;
+                }
+
+                if (rParentPageId != null && !matchesParent(item, rParentPageId)) {
+                    continue;
+                }
+
+                result.add(toPageInfo(item, lastEditedTime));
+            }
+
+            hasMore = Boolean.TRUE.equals(response.getHasMore());
+            cursor = response.getNextCursor();
+        }
+
+        return result;
+    }
+
+    private Map<String, Object> buildSearchBody(String rQuery, String cursor) {
+        var body = new HashMap<String, Object>();
+        body.put("filter", Map.of("property", "object", "value", "page"));
+        body.put("sort", Map.of("direction", "descending", "timestamp", "last_edited_time"));
+        body.put("page_size", PAGE_SIZE);
+        if (rQuery != null) {
+            body.put("query", rQuery);
+        }
+        if (cursor != null) {
+            body.put("start_cursor", cursor);
+        }
+        return body;
+    }
+
+    private NotionResponse callSearchApi(RunContext runContext, String rApiToken, Map<String, Object> body) throws Exception {
+        var jsonBody = MAPPER.writeValueAsString(body);
+        var requestBuilder = HttpRequest.builder()
+            .uri(URI.create(NotionConnection.getBaseUrl() + NotionConnection.SEARCH_ENDPOINT))
+            .method("POST")
+            .body(HttpRequest.StringRequestBody.builder().content(jsonBody).build())
+            .addHeader("Authorization", "Bearer " + rApiToken)
+            .addHeader("Notion-Version", NotionConnection.NOTION_API_VERSION)
+            .addHeader("Content-Type", NotionConnection.JSON_CONTENT_TYPE);
+
+        try (var client = new HttpClient(runContext, options)) {
+            return client.request(requestBuilder.build(), NotionResponse.class).getBody();
+        }
+    }
+
+    private boolean matchesParent(Map<String, Object> page, String expectedParentId) {
+        var parent = page.get("parent");
+        if (!(parent instanceof Map<?, ?> parentMap)) {
+            return false;
+        }
+        return "page_id".equals(parentMap.get("type")) && expectedParentId.equals(parentMap.get("page_id"));
+    }
+
+    private PageInfo toPageInfo(Map<String, Object> page, Instant lastEditedTime) {
+        var pageId = (String) page.get("id");
+        var url = (String) page.get("url");
+        var title = extractTitle(page);
+        return PageInfo.builder()
+            .pageId(pageId)
+            .url(url)
+            .title(title)
+            .lastEditedTime(lastEditedTime)
+            .build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private String extractTitle(Map<String, Object> page) {
+        var properties = page.get("properties");
+        if (!(properties instanceof Map<?, ?> propsMap)) {
+            return null;
+        }
+        // Try "title" then "Name" — Notion uses "title" for pages, "Name" for database items.
+        for (var key : new String[]{"title", "Name"}) {
+            var prop = propsMap.get(key);
+            if (!(prop instanceof Map<?, ?> propMap)) {
+                continue;
+            }
+            var titleArray = propMap.get("title");
+            if (!(titleArray instanceof List<?> list) || list.isEmpty()) {
+                continue;
+            }
+            var first = list.getFirst();
+            if (first instanceof Map<?, ?> entry) {
+                var plainText = entry.get("plain_text");
+                if (plainText != null) {
+                    return plainText.toString();
+                }
+            }
+        }
+        return null;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PageInfo {
+
+        @Schema(
+            title = "Page ID",
+            description = "The unique identifier of the updated Notion page."
+        )
+        private String pageId;
+
+        @Schema(
+            title = "Page URL",
+            description = "The URL of the updated page in Notion."
+        )
+        private String url;
+
+        @Schema(
+            title = "Page title",
+            description = "The title of the updated page, or null if the title could not be extracted."
+        )
+        private String title;
+
+        @Schema(
+            title = "Last edited time",
+            description = "The timestamp when the page was last edited."
+        )
+        private Instant lastEditedTime;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Output implements io.kestra.core.models.tasks.Output {
+
+        @Schema(
+            title = "Updated pages",
+            description = "The list of Notion pages that were updated since the last trigger evaluation."
+        )
+        private List<PageInfo> updatedPages;
+    }
+}

--- a/src/main/java/io/kestra/plugin/notion/page/package-info.java
+++ b/src/main/java/io/kestra/plugin/notion/page/package-info.java
@@ -1,6 +1,6 @@
 @PluginSubGroup(
     title = "Notion",
-    description = "This sub-group of plugins contains tasks for using Notion API to create, read, update, and archive pages with markdown content.", categories = {
+    description = "This sub-group of plugins contains tasks and triggers for using the Notion API to create, read, update, and archive pages with markdown content, and to react to page updates via polling.", categories = {
         PluginSubGroup.PluginCategory.BUSINESS
     }
 )

--- a/src/test/java/io/kestra/plugin/notion/page/UpdateTriggerTest.java
+++ b/src/test/java/io/kestra/plugin/notion/page/UpdateTriggerTest.java
@@ -1,0 +1,482 @@
+package io.kestra.plugin.notion.page;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.conditions.ConditionContext;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.triggers.TriggerContext;
+import io.kestra.core.models.executions.Execution;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.serializers.JacksonMapper;
+import io.kestra.core.utils.TestsUtils;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+@KestraTest
+class UpdateTriggerTest {
+
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    private static final ObjectMapper MAPPER = JacksonMapper.ofJson(false);
+
+    @Test
+    void builderPattern_setsPropertiesCorrectly() {
+        var trigger = UpdateTrigger.builder()
+            .id("test-trigger")
+            .type(UpdateTrigger.class.getName())
+            .apiToken(Property.ofValue("test-token"))
+            .interval(Duration.ofMinutes(5))
+            .query(Property.ofValue("Meeting"))
+            .parentPageId(Property.ofValue("12345678-1234-1234-1234-123456789abc"))
+            .build();
+
+        assertThat(trigger, notNullValue());
+        assertThat(trigger.getApiToken(), notNullValue());
+        assertThat(trigger.getInterval(), equalTo(Duration.ofMinutes(5)));
+        assertThat(trigger.getQuery(), notNullValue());
+        assertThat(trigger.getParentPageId(), notNullValue());
+    }
+
+    @Test
+    void builderPattern_minimalFields_works() {
+        var trigger = UpdateTrigger.builder()
+            .id("minimal")
+            .type(UpdateTrigger.class.getName())
+            .apiToken(Property.ofValue("test-token"))
+            .build();
+
+        assertThat(trigger, notNullValue());
+        assertThat(trigger.getQuery(), nullValue());
+        assertThat(trigger.getParentPageId(), nullValue());
+        assertThat(trigger.getInterval(), equalTo(Duration.ofMinutes(5)));
+    }
+
+    @Test
+    void propertyTypes_areCorrect() {
+        var trigger = UpdateTrigger.builder()
+            .id("types")
+            .type(UpdateTrigger.class.getName())
+            .apiToken(Property.ofValue("token"))
+            .query(Property.ofValue("q"))
+            .parentPageId(Property.ofValue("pid"))
+            .build();
+
+        assertThat(trigger.getApiToken(), instanceOf(Property.class));
+        assertThat(trigger.getQuery(), instanceOf(Property.class));
+        assertThat(trigger.getParentPageId(), instanceOf(Property.class));
+    }
+
+    @Test
+    void inheritance_extendsAbstractTrigger() {
+        var trigger = UpdateTrigger.builder()
+            .id("inherit")
+            .type(UpdateTrigger.class.getName())
+            .apiToken(Property.ofValue("token"))
+            .build();
+
+        assertThat(trigger, instanceOf(io.kestra.core.models.triggers.AbstractTrigger.class));
+        assertThat(trigger, instanceOf(io.kestra.core.models.triggers.PollingTriggerInterface.class));
+        assertThat(trigger, instanceOf(io.kestra.core.models.triggers.TriggerOutput.class));
+    }
+
+    @Test
+    void singlePage_newerThanWatermark_firesExecution() throws Exception {
+        var trigger = UpdateTrigger.builder()
+            .id("t1")
+            .type(UpdateTrigger.class.getName())
+            .apiToken(Property.ofValue("test-token"))
+            .interval(Duration.ofMinutes(5))
+            .build();
+
+        var entry = TestsUtils.mockTrigger(runContextFactory, trigger);
+        var conditionContext = entry.getKey();
+
+        var wireMock = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        wireMock.start();
+        var previousUrl = System.getProperty("notion.api.base.url");
+        System.setProperty("notion.api.base.url", wireMock.baseUrl());
+
+        try {
+            configureFor("localhost", wireMock.port());
+
+            var recentTime = Instant.now().toString();
+            var responseBody = Map.of(
+                "object", "list",
+                "results", List.of(pageJson("page-1", "https://notion.so/page-1", "My Page", recentTime)),
+                "has_more", false
+            );
+
+            wireMock.stubFor(
+                post(urlEqualTo("/v1/search"))
+                    .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(MAPPER.writeValueAsString(responseBody))
+                        .withStatus(200))
+            );
+
+            // Watermark 10 minutes in the past so the "recent" page qualifies.
+            var context = triggerContext(ZonedDateTime.now().minusMinutes(10));
+
+            Optional<Execution> result = trigger.evaluate(conditionContext, context);
+
+            assertThat(result.isPresent(), is(true));
+        } finally {
+            wireMock.stop();
+            restoreBaseUrl(previousUrl);
+        }
+    }
+
+    @Test
+    void allPagesOlderThanWatermark_returnsEmpty() throws Exception {
+        var trigger = UpdateTrigger.builder()
+            .id("t2")
+            .type(UpdateTrigger.class.getName())
+            .apiToken(Property.ofValue("test-token"))
+            .build();
+
+        var entry = TestsUtils.mockTrigger(runContextFactory, trigger);
+        var conditionContext = entry.getKey();
+
+        var wireMock = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        wireMock.start();
+        var previousUrl = System.getProperty("notion.api.base.url");
+        System.setProperty("notion.api.base.url", wireMock.baseUrl());
+
+        try {
+            configureFor("localhost", wireMock.port());
+
+            // Page edited 2 hours ago; watermark is 1 hour ago → page is older.
+            var oldTime = Instant.now().minusSeconds(7200).toString();
+            var responseBody = Map.of(
+                "object", "list",
+                "results", List.of(pageJson("page-old", "https://notion.so/page-old", "Old Page", oldTime)),
+                "has_more", false
+            );
+
+            wireMock.stubFor(
+                post(urlEqualTo("/v1/search"))
+                    .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(MAPPER.writeValueAsString(responseBody))
+                        .withStatus(200))
+            );
+
+            var context = triggerContext(ZonedDateTime.now().minusHours(1));
+
+            Optional<Execution> result = trigger.evaluate(conditionContext, context);
+
+            assertThat(result.isPresent(), is(false));
+        } finally {
+            wireMock.stop();
+            restoreBaseUrl(previousUrl);
+        }
+    }
+
+    @Test
+    void pagination_collectsAllQualifyingPages() throws Exception {
+        var trigger = UpdateTrigger.builder()
+            .id("t3")
+            .type(UpdateTrigger.class.getName())
+            .apiToken(Property.ofValue("test-token"))
+            .build();
+
+        var entry = TestsUtils.mockTrigger(runContextFactory, trigger);
+        var conditionContext = entry.getKey();
+
+        var wireMock = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        wireMock.start();
+        var previousUrl = System.getProperty("notion.api.base.url");
+        System.setProperty("notion.api.base.url", wireMock.baseUrl());
+
+        try {
+            configureFor("localhost", wireMock.port());
+
+            var recentTime = Instant.now().toString();
+
+            var firstPage = Map.of(
+                "object", "list",
+                "results", List.of(pageJson("page-1", "https://notion.so/page-1", "Page 1", recentTime)),
+                "has_more", true,
+                "next_cursor", "cursor-abc"
+            );
+            var secondPage = Map.of(
+                "object", "list",
+                "results", List.of(pageJson("page-2", "https://notion.so/page-2", "Page 2", recentTime)),
+                "has_more", false
+            );
+
+            wireMock.stubFor(
+                post(urlEqualTo("/v1/search"))
+                    .withRequestBody(containing("\"page_size\":" + 100))
+                    .inScenario("pagination")
+                    .whenScenarioStateIs(com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED)
+                    .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(MAPPER.writeValueAsString(firstPage))
+                        .withStatus(200))
+                    .willSetStateTo("second")
+            );
+            wireMock.stubFor(
+                post(urlEqualTo("/v1/search"))
+                    .withRequestBody(containing("cursor-abc"))
+                    .inScenario("pagination")
+                    .whenScenarioStateIs("second")
+                    .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(MAPPER.writeValueAsString(secondPage))
+                        .withStatus(200))
+            );
+
+            var context = triggerContext(ZonedDateTime.now().minusHours(1));
+
+            Optional<Execution> result = trigger.evaluate(conditionContext, context);
+
+            assertThat(result.isPresent(), is(true));
+        } finally {
+            wireMock.stop();
+            restoreBaseUrl(previousUrl);
+        }
+    }
+
+    @Test
+    void parentPageIdFilter_onlyMatchingParentSurvives() throws Exception {
+        var targetParent = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+        var otherParent = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+
+        var trigger = UpdateTrigger.builder()
+            .id("t4")
+            .type(UpdateTrigger.class.getName())
+            .apiToken(Property.ofValue("test-token"))
+            .parentPageId(Property.ofValue(targetParent))
+            .build();
+
+        var entry = TestsUtils.mockTrigger(runContextFactory, trigger);
+        var conditionContext = entry.getKey();
+
+        var wireMock = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        wireMock.start();
+        var previousUrl = System.getProperty("notion.api.base.url");
+        System.setProperty("notion.api.base.url", wireMock.baseUrl());
+
+        try {
+            configureFor("localhost", wireMock.port());
+
+            var recentTime = Instant.now().toString();
+            var matchingPage = pageJsonWithParent("match-page", "https://notion.so/match", "Match", recentTime, targetParent);
+            var nonMatchingPage = pageJsonWithParent("skip-page", "https://notion.so/skip", "Skip", recentTime, otherParent);
+
+            var responseBody = Map.of(
+                "object", "list",
+                "results", List.of(matchingPage, nonMatchingPage),
+                "has_more", false
+            );
+
+            wireMock.stubFor(
+                post(urlEqualTo("/v1/search"))
+                    .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(MAPPER.writeValueAsString(responseBody))
+                        .withStatus(200))
+            );
+
+            var context = triggerContext(ZonedDateTime.now().minusHours(1));
+
+            Optional<Execution> result = trigger.evaluate(conditionContext, context);
+
+            assertThat(result.isPresent(), is(true));
+        } finally {
+            wireMock.stop();
+            restoreBaseUrl(previousUrl);
+        }
+    }
+
+    @Test
+    void parentPageIdFilter_noMatch_returnsEmpty() throws Exception {
+        var targetParent = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+        var otherParent = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+
+        var trigger = UpdateTrigger.builder()
+            .id("t5")
+            .type(UpdateTrigger.class.getName())
+            .apiToken(Property.ofValue("test-token"))
+            .parentPageId(Property.ofValue(targetParent))
+            .build();
+
+        var entry = TestsUtils.mockTrigger(runContextFactory, trigger);
+        var conditionContext = entry.getKey();
+
+        var wireMock = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        wireMock.start();
+        var previousUrl = System.getProperty("notion.api.base.url");
+        System.setProperty("notion.api.base.url", wireMock.baseUrl());
+
+        try {
+            configureFor("localhost", wireMock.port());
+
+            var recentTime = Instant.now().toString();
+            var nonMatchingPage = pageJsonWithParent("skip-page", "https://notion.so/skip", "Skip", recentTime, otherParent);
+
+            var responseBody = Map.of(
+                "object", "list",
+                "results", List.of(nonMatchingPage),
+                "has_more", false
+            );
+
+            wireMock.stubFor(
+                post(urlEqualTo("/v1/search"))
+                    .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(MAPPER.writeValueAsString(responseBody))
+                        .withStatus(200))
+            );
+
+            var context = triggerContext(ZonedDateTime.now().minusHours(1));
+
+            Optional<Execution> result = trigger.evaluate(conditionContext, context);
+
+            assertThat(result.isPresent(), is(false));
+        } finally {
+            wireMock.stop();
+            restoreBaseUrl(previousUrl);
+        }
+    }
+
+    @Test
+    void query_sentInPostBody_whenConfigured() throws Exception {
+        var trigger = UpdateTrigger.builder()
+            .id("t6")
+            .type(UpdateTrigger.class.getName())
+            .apiToken(Property.ofValue("test-token"))
+            .query(Property.ofValue("Sprint"))
+            .build();
+
+        var entry = TestsUtils.mockTrigger(runContextFactory, trigger);
+        var conditionContext = entry.getKey();
+
+        var wireMock = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        wireMock.start();
+        var previousUrl = System.getProperty("notion.api.base.url");
+        System.setProperty("notion.api.base.url", wireMock.baseUrl());
+
+        try {
+            configureFor("localhost", wireMock.port());
+
+            var responseBody = Map.of(
+                "object", "list",
+                "results", List.of(),
+                "has_more", false
+            );
+
+            wireMock.stubFor(
+                post(urlEqualTo("/v1/search"))
+                    .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(MAPPER.writeValueAsString(responseBody))
+                        .withStatus(200))
+            );
+
+            var context = triggerContext(ZonedDateTime.now().minusMinutes(30));
+
+            trigger.evaluate(conditionContext, context);
+
+            wireMock.verify(postRequestedFor(urlEqualTo("/v1/search"))
+                .withRequestBody(containing("\"query\":\"Sprint\"")));
+        } finally {
+            wireMock.stop();
+            restoreBaseUrl(previousUrl);
+        }
+    }
+
+    @Test
+    @Disabled("Requires NOTION_API_TOKEN set in the environment — run manually")
+    void integration_realApi_firesTriggerOnUpdatedPages() throws Exception {
+        var trigger = UpdateTrigger.builder()
+            .id("integration")
+            .type(UpdateTrigger.class.getName())
+            .apiToken(Property.ofValue(System.getenv("NOTION_API_TOKEN")))
+            .interval(Duration.ofMinutes(1))
+            .build();
+
+        var entry = TestsUtils.mockTrigger(runContextFactory, trigger);
+        var conditionContext = entry.getKey();
+
+        var context = triggerContext(ZonedDateTime.now().minusDays(7));
+
+        var result = trigger.evaluate(conditionContext, context);
+        assertThat(result, notNullValue());
+    }
+
+    // --- helpers ---
+
+    private static TriggerContext triggerContext(ZonedDateTime date) {
+        return TriggerContext.builder()
+            .tenantId(null)
+            .namespace("company.team")
+            .flowId("test-flow")
+            .triggerId("test-trigger")
+            .date(date)
+            .build();
+    }
+
+    private static Map<String, Object> pageJson(String id, String url, String title, String lastEditedTime) {
+        return Map.of(
+            "object", "page",
+            "id", id,
+            "url", url,
+            "last_edited_time", lastEditedTime,
+            "properties", Map.of(
+                "title", Map.of(
+                    "title", List.of(Map.of("plain_text", title))
+                )
+            )
+        );
+    }
+
+    private static Map<String, Object> pageJsonWithParent(
+        String id, String url, String title, String lastEditedTime, String parentPageId
+    ) {
+        return Map.of(
+            "object", "page",
+            "id", id,
+            "url", url,
+            "last_edited_time", lastEditedTime,
+            "parent", Map.of("type", "page_id", "page_id", parentPageId),
+            "properties", Map.of(
+                "title", Map.of(
+                    "title", List.of(Map.of("plain_text", title))
+                )
+            )
+        );
+    }
+
+    private static void restoreBaseUrl(String previousUrl) {
+        if (previousUrl == null) {
+            System.clearProperty("notion.api.base.url");
+        } else {
+            System.setProperty("notion.api.base.url", previousUrl);
+        }
+    }
+}

--- a/src/test/java/io/kestra/plugin/notion/page/UpdateTriggerTest.java
+++ b/src/test/java/io/kestra/plugin/notion/page/UpdateTriggerTest.java
@@ -3,6 +3,7 @@ package io.kestra.plugin.notion.page;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -143,6 +144,59 @@ class UpdateTriggerTest {
             Optional<Execution> result = trigger.evaluate(conditionContext, context);
 
             assertThat(result.isPresent(), is(true));
+        } finally {
+            wireMock.stop();
+            restoreBaseUrl(previousUrl);
+        }
+    }
+
+    @Test
+    void notionMinutePrecision_pageInSameMinuteAsWatermark_isDetected() throws Exception {
+        // Notion truncates last_edited_time to minutes (seconds/ms always 0).
+        // The previous evaluation timestamp has sub-second precision. If we compare
+        // without truncation, a page edited 30s after the watermark minute starts
+        // appears as "equal to" the watermark and is silently skipped.
+        var trigger = UpdateTrigger.builder()
+            .id("t-precision")
+            .type(UpdateTrigger.class.getName())
+            .apiToken(Property.ofValue("test-token"))
+            .build();
+
+        var entry = TestsUtils.mockTrigger(runContextFactory, trigger);
+        var conditionContext = entry.getKey();
+
+        var wireMock = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        wireMock.start();
+        var previousUrl = System.getProperty("notion.api.base.url");
+        System.setProperty("notion.api.base.url", wireMock.baseUrl());
+
+        try {
+            configureFor("localhost", wireMock.port());
+
+            // Simulate Notion's minute-precision: page edited at HH:mm:30 is reported as HH:mm:00.
+            var notionTimestamp = Instant.now().truncatedTo(ChronoUnit.MINUTES).toString();
+
+            var responseBody = Map.of(
+                "object", "list",
+                "results", List.of(pageJson("page-precision", "https://notion.so/page", "Precision Page", notionTimestamp)),
+                "has_more", false
+            );
+
+            wireMock.stubFor(
+                post(urlEqualTo("/v1/search"))
+                    .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(MAPPER.writeValueAsString(responseBody))
+                        .withStatus(200))
+            );
+
+            // Watermark is 30 seconds into the same minute (sub-second precision from real evaluation).
+            var watermarkInstant = Instant.now().truncatedTo(ChronoUnit.MINUTES).plusSeconds(30);
+            var context = triggerContext(ZonedDateTime.ofInstant(watermarkInstant, java.time.ZoneOffset.UTC));
+
+            Optional<Execution> result = trigger.evaluate(conditionContext, context);
+
+            assertThat("page at minute boundary must not be silently skipped", result.isPresent(), is(true));
         } finally {
             wireMock.stop();
             restoreBaseUrl(previousUrl);


### PR DESCRIPTION
## Summary

- Adds `UpdateTrigger` in `io.kestra.plugin.notion.page`, a `PollingTriggerInterface` that polls `POST /v1/search` each interval and fires a flow execution when Notion pages are updated
- Watermark taken from `TriggerContext.date`; pages with `last_edited_time > watermark` qualify; sorted descending for early-exit pagination
- Optional `query` property narrows search server-side; optional `parentPageId` filters client-side (Notion Search API has no server-side parent filter)
- `NotionConnection.getBaseUrl()` visibility widened from `protected` to `public` to allow reuse from the trigger (which cannot extend `NotionConnection` since it already extends `AbstractTrigger`)
- 8 unit/WireMock tests + 1 `@Disabled` integration test; all non-disabled tests pass

closes: https://github.com/kestra-io/plugin-notion/issues/50

## Test plan

- [x] `./gradlew cleanTest test --rerun-tasks` passes (8 pass, 1 skipped)
- [x] `./gradlew shadowJar` builds cleanly
- [ ] Manual integration test: set `NOTION_API_TOKEN`, enable `integration_realApi_firesTriggerOnUpdatedPages` and run