### PR TITLE
fix(markdown): render GFM tables, inline formatting and escapes as Notion blocks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,12 @@ dependencies {
 
     // Logs
     compileOnly 'org.slf4j:slf4j-api:2.0.17'
+
+    // Markdown parsing (CommonMark + GFM tables/strikethrough/task-lists), bundled into the plugin jar via shadowJar
+    implementation 'org.commonmark:commonmark:0.29.0'
+    implementation 'org.commonmark:commonmark-ext-gfm-tables:0.29.0'
+    implementation 'org.commonmark:commonmark-ext-gfm-strikethrough:0.29.0'
+    implementation 'org.commonmark:commonmark-ext-task-list-items:0.29.0'
 }
 
 

--- a/src/main/java/io/kestra/plugin/notion/utils/MarkdownConverter.java
+++ b/src/main/java/io/kestra/plugin/notion/utils/MarkdownConverter.java
@@ -42,6 +42,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
+import io.kestra.core.serializers.JacksonMapper;
+
 /**
  * Utility class for converting between Markdown and Notion blocks format.
  * Supports bidirectional conversion for common content types.
@@ -57,7 +59,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 public class MarkdownConverter {
 
     private static final Logger logger = LoggerFactory.getLogger(MarkdownConverter.class);
-    private static final ObjectMapper mapper = new ObjectMapper();
+    private static final ObjectMapper mapper = JacksonMapper.ofJson();
 
     private static final List<Extension> EXTENSIONS = List.of(
         TablesExtension.create(),
@@ -97,10 +99,6 @@ public class MarkdownConverter {
         Map.entry("plaintext", "plain text"), Map.entry("txt", "plain text")
     );
 
-    // =========================================================================
-    // Markdown -> Notion blocks
-    // =========================================================================
-
     /**
      * Convert markdown content to Notion blocks array
      *
@@ -108,7 +106,7 @@ public class MarkdownConverter {
      * @return Array of Notion blocks
      */
     public static ArrayNode markdownToBlocks(String markdown) {
-        ArrayNode blocks = mapper.createArrayNode();
+        var blocks = mapper.createArrayNode();
 
         if (markdown == null || markdown.trim().isEmpty()) {
             return blocks;
@@ -116,8 +114,8 @@ public class MarkdownConverter {
 
         logger.debug("Converting markdown to Notion blocks: {} chars", markdown.length());
 
-        Node document = PARSER.parse(markdown);
-        for (Node node = document.getFirstChild(); node != null; node = node.getNext()) {
+        var document = PARSER.parse(markdown);
+        for (var node = document.getFirstChild(); node != null; node = node.getNext()) {
             appendBlock(blocks, node);
         }
 
@@ -138,10 +136,15 @@ public class MarkdownConverter {
             case OrderedList list -> appendListItems(out, list, true);
             case BlockQuote quote -> out.add(quoteBlock(quote));
             case ThematicBreak thematicBreak -> out.add(block("divider", mapper.createObjectNode()));
-            case TableBlock table -> out.add(tableBlock(table));
+            case TableBlock table -> {
+                var tableNode = tableBlock(table);
+                if (tableNode != null) {
+                    out.add(tableNode);
+                }
+            }
             default -> {
                 // Fallback: surface any inline content as a paragraph so nothing is silently dropped.
-                ArrayNode richText = inlineRichText(node);
+                var richText = inlineRichText(node);
                 if (!richText.isEmpty()) {
                     out.add(wrapParagraph(richText));
                 }
@@ -150,7 +153,7 @@ public class MarkdownConverter {
     }
 
     private static void appendListItems(ArrayNode out, Node list, boolean ordered) {
-        for (Node item = list.getFirstChild(); item != null; item = item.getNext()) {
+        for (var item = list.getFirstChild(); item != null; item = item.getNext()) {
             if (item instanceof ListItem listItem) {
                 out.add(listItemBlock(listItem, ordered));
             }
@@ -162,7 +165,7 @@ public class MarkdownConverter {
      * {@code to_do} block; nested lists/blocks under the item become Notion children.
      */
     private static ObjectNode listItemBlock(ListItem item, boolean ordered) {
-        Node first = item.getFirstChild();
+        var first = item.getFirstChild();
 
         // The task-list extension prepends a TaskListItemMarker as the list item's first child;
         // its presence turns the item into a Notion to_do block.
@@ -172,24 +175,18 @@ public class MarkdownConverter {
             first = first.getNext();
         }
 
-        ArrayNode richText;
-        Node childStart;
-        if (first instanceof Paragraph) {
-            richText = inlineRichText(first);
-            childStart = first.getNext();
-        } else {
-            richText = mapper.createArrayNode();
-            childStart = first;
-        }
+        var hasParagraph = first instanceof Paragraph;
+        var richText = hasParagraph ? inlineRichText(first) : mapper.createArrayNode();
+        var childStart = hasParagraph ? first.getNext() : first;
 
-        ArrayNode children = mapper.createArrayNode();
-        for (Node child = childStart; child != null; child = child.getNext()) {
+        var children = mapper.createArrayNode();
+        for (var child = childStart; child != null; child = child.getNext()) {
             appendBlock(children, child);
         }
 
-        String type = marker != null ? "to_do" : (ordered ? "numbered_list_item" : "bulleted_list_item");
+        var type = marker != null ? "to_do" : (ordered ? "numbered_list_item" : "bulleted_list_item");
 
-        ObjectNode body = mapper.createObjectNode();
+        var body = mapper.createObjectNode();
         body.set("rich_text", richText);
         if (marker != null) {
             body.put("checked", marker.isChecked());
@@ -202,20 +199,20 @@ public class MarkdownConverter {
     }
 
     private static ObjectNode quoteBlock(BlockQuote quote) {
-        ArrayNode richText = mapper.createArrayNode();
-        ArrayNode children = mapper.createArrayNode();
+        var richText = mapper.createArrayNode();
+        var children = mapper.createArrayNode();
 
-        Node first = quote.getFirstChild();
-        Node childStart = quote.getFirstChild();
+        var first = quote.getFirstChild();
+        var childStart = first;
         if (first instanceof Paragraph) {
             richText = inlineRichText(first);
             childStart = first.getNext();
         }
-        for (Node child = childStart; child != null; child = child.getNext()) {
+        for (var child = childStart; child != null; child = child.getNext()) {
             appendBlock(children, child);
         }
 
-        ObjectNode body = mapper.createObjectNode();
+        var body = mapper.createObjectNode();
         body.set("rich_text", richText);
         if (!children.isEmpty()) {
             body.set("children", children);
@@ -224,17 +221,17 @@ public class MarkdownConverter {
     }
 
     private static ObjectNode tableBlock(TableBlock table) {
-        List<ArrayNode> rowCells = new ArrayList<>();
-        int width = 0;
+        var rowCells = new ArrayList<ArrayNode>();
+        var width = 0;
 
         // A TableBlock contains a TableHead and (optionally) a TableBody, each holding TableRows.
-        for (Node section = table.getFirstChild(); section != null; section = section.getNext()) {
-            for (Node row = section.getFirstChild(); row != null; row = row.getNext()) {
+        for (var section = table.getFirstChild(); section != null; section = section.getNext()) {
+            for (var row = section.getFirstChild(); row != null; row = row.getNext()) {
                 if (!(row instanceof TableRow)) {
                     continue;
                 }
-                ArrayNode cells = mapper.createArrayNode();
-                for (Node cell = row.getFirstChild(); cell != null; cell = cell.getNext()) {
+                var cells = mapper.createArrayNode();
+                for (var cell = row.getFirstChild(); cell != null; cell = cell.getNext()) {
                     if (cell instanceof TableCell) {
                         cells.add(inlineRichText(cell));
                     }
@@ -244,18 +241,23 @@ public class MarkdownConverter {
             }
         }
 
-        ArrayNode children = mapper.createArrayNode();
-        for (ArrayNode cells : rowCells) {
+        if (width == 0) {
+            // Degenerate table (e.g. a separator-only row) — Notion rejects table_width: 0.
+            return null;
+        }
+
+        var children = mapper.createArrayNode();
+        for (var cells : rowCells) {
             // Notion requires every row to have exactly table_width cells.
             while (cells.size() < width) {
                 cells.add(mapper.createArrayNode());
             }
-            ObjectNode rowBody = mapper.createObjectNode();
+            var rowBody = mapper.createObjectNode();
             rowBody.set("cells", cells);
             children.add(block("table_row", rowBody));
         }
 
-        ObjectNode body = mapper.createObjectNode();
+        var body = mapper.createObjectNode();
         body.put("table_width", width);
         body.put("has_column_header", true);
         body.put("has_row_header", false);
@@ -264,22 +266,22 @@ public class MarkdownConverter {
     }
 
     private static ObjectNode headingBlock(Heading heading) {
-        String type = "heading_" + Math.min(heading.getLevel(), MAX_HEADING_LEVEL);
-        ObjectNode body = mapper.createObjectNode();
+        var type = "heading_" + Math.min(heading.getLevel(), MAX_HEADING_LEVEL);
+        var body = mapper.createObjectNode();
         body.set("rich_text", inlineRichText(heading));
         return block(type, body);
     }
 
     private static ObjectNode wrapParagraph(ArrayNode richText) {
-        ObjectNode body = mapper.createObjectNode();
+        var body = mapper.createObjectNode();
         body.set("rich_text", richText);
         return block("paragraph", body);
     }
 
     private static ObjectNode codeBlock(String content, String info) {
-        ObjectNode body = mapper.createObjectNode();
+        var body = mapper.createObjectNode();
 
-        ArrayNode richText = mapper.createArrayNode();
+        var richText = mapper.createArrayNode();
         addText(richText, stripTrailingNewline(content), Ctx.EMPTY);
         body.set("rich_text", richText);
 
@@ -297,7 +299,7 @@ public class MarkdownConverter {
         if (info == null || info.isBlank()) {
             return "plain text";
         }
-        String token = info.trim().split("\\s+")[0].toLowerCase(Locale.ROOT);
+        var token = info.trim().split("\\s+")[0].toLowerCase(Locale.ROOT);
         token = LANGUAGE_ALIASES.getOrDefault(token, token);
         return NOTION_CODE_LANGUAGES.contains(token) ? token : "plain text";
     }
@@ -310,20 +312,18 @@ public class MarkdownConverter {
     }
 
     private static ObjectNode block(String type, ObjectNode body) {
-        ObjectNode block = mapper.createObjectNode();
+        var block = mapper.createObjectNode();
         block.put("object", "block");
         block.put("type", type);
         block.set(type, body);
         return block;
     }
 
-    // ---- Inline rich text -------------------------------------------------
-
     /**
      * Build a Notion {@code rich_text} array from a block node's inline children.
      */
     private static ArrayNode inlineRichText(Node parent) {
-        ArrayNode out = mapper.createArrayNode();
+        var out = mapper.createArrayNode();
         collectInlines(parent, out, Ctx.EMPTY);
         return out;
     }
@@ -333,7 +333,7 @@ public class MarkdownConverter {
      * nested emphasis and links so e.g. a bold link is both bold and a link.
      */
     private static void collectInlines(Node parent, ArrayNode out, Ctx ctx) {
-        for (Node child = parent.getFirstChild(); child != null; child = child.getNext()) {
+        for (var child = parent.getFirstChild(); child != null; child = child.getNext()) {
             switch (child) {
                 case Text text -> addText(out, text.getLiteral(), ctx);
                 case StrongEmphasis strong -> collectInlines(child, out, ctx.withBold());
@@ -341,7 +341,7 @@ public class MarkdownConverter {
                 case Strikethrough strikethrough -> collectInlines(child, out, ctx.withStrike());
                 case Code code -> addText(out, code.getLiteral(), ctx.withCode());
                 case Link link -> {
-                    String dest = link.getDestination();
+                    var dest = link.getDestination();
                     collectInlines(child, out, dest == null || dest.isBlank() ? ctx : ctx.withHref(dest));
                 }
                 case Image image -> collectInlines(child, out, ctx); // render alt-text inlines as plain text
@@ -359,13 +359,13 @@ public class MarkdownConverter {
             return;
         }
 
-        ObjectNode item = mapper.createObjectNode();
+        var item = mapper.createObjectNode();
         item.put("type", "text");
 
-        ObjectNode text = mapper.createObjectNode();
+        var text = mapper.createObjectNode();
         text.put("content", content);
         if (ctx.href() != null) {
-            ObjectNode link = mapper.createObjectNode();
+            var link = mapper.createObjectNode();
             link.put("url", ctx.href());
             text.set("link", link);
         }
@@ -380,7 +380,7 @@ public class MarkdownConverter {
     }
 
     private static ObjectNode annotations(Ctx ctx) {
-        ObjectNode annotations = mapper.createObjectNode();
+        var annotations = mapper.createObjectNode();
         annotations.put("bold", ctx.bold());
         annotations.put("italic", ctx.italic());
         annotations.put("strikethrough", ctx.strike());
@@ -417,10 +417,6 @@ public class MarkdownConverter {
             return new Ctx(bold, italic, code, strike, url);
         }
     }
-
-    // =========================================================================
-    // Notion blocks -> Markdown
-    // =========================================================================
 
     /**
      * Convert Notion blocks to markdown content

--- a/src/main/java/io/kestra/plugin/notion/utils/MarkdownConverter.java
+++ b/src/main/java/io/kestra/plugin/notion/utils/MarkdownConverter.java
@@ -1,9 +1,39 @@
 package io.kestra.plugin.notion.utils;
 
-import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 
+import org.commonmark.Extension;
+import org.commonmark.ext.gfm.strikethrough.Strikethrough;
+import org.commonmark.ext.gfm.strikethrough.StrikethroughExtension;
+import org.commonmark.ext.gfm.tables.TableBlock;
+import org.commonmark.ext.gfm.tables.TableCell;
+import org.commonmark.ext.gfm.tables.TableRow;
+import org.commonmark.ext.gfm.tables.TablesExtension;
+import org.commonmark.ext.task.list.items.TaskListItemMarker;
+import org.commonmark.ext.task.list.items.TaskListItemsExtension;
+import org.commonmark.node.BlockQuote;
+import org.commonmark.node.BulletList;
+import org.commonmark.node.Code;
+import org.commonmark.node.Emphasis;
+import org.commonmark.node.FencedCodeBlock;
+import org.commonmark.node.HardLineBreak;
+import org.commonmark.node.Heading;
+import org.commonmark.node.Image;
+import org.commonmark.node.IndentedCodeBlock;
+import org.commonmark.node.Link;
+import org.commonmark.node.ListItem;
+import org.commonmark.node.Node;
+import org.commonmark.node.OrderedList;
+import org.commonmark.node.Paragraph;
+import org.commonmark.node.SoftLineBreak;
+import org.commonmark.node.StrongEmphasis;
+import org.commonmark.node.Text;
+import org.commonmark.node.ThematicBreak;
+import org.commonmark.parser.Parser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -15,96 +45,80 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 /**
  * Utility class for converting between Markdown and Notion blocks format.
  * Supports bidirectional conversion for common content types.
+ *
+ * <p>
+ * The Markdown -> blocks direction parses with the CommonMark reference parser
+ * (plus the GFM tables, strikethrough and task-list extensions) and walks the
+ * resulting AST into Notion block objects. This renders block-level elements,
+ * GFM tables, inline annotations (bold/italic/code/strikethrough/links) and
+ * backslash escapes as real Notion structures rather than literal text.
+ * </p>
  */
 public class MarkdownConverter {
 
     private static final Logger logger = LoggerFactory.getLogger(MarkdownConverter.class);
     private static final ObjectMapper mapper = new ObjectMapper();
 
-    // Markdown patterns
-    private static final Pattern HEADER_PATTERN = Pattern.compile("^(#{1,6})\\s+(.+)$", Pattern.MULTILINE);
-    private static final Pattern BOLD_PATTERN = Pattern.compile("\\*\\*(.+?)\\*\\*");
-    private static final Pattern ITALIC_PATTERN = Pattern.compile("\\*(.+?)\\*");
-    private static final Pattern CODE_PATTERN = Pattern.compile("`(.+?)`");
-    private static final Pattern LINK_PATTERN = Pattern.compile("\\[([^\\]]+)\\]\\(([^\\)]+)\\)");
-    private static final Pattern LIST_ITEM_PATTERN = Pattern.compile("^[\\s]*[-*+]\\s+(.+)$", Pattern.MULTILINE);
-    private static final Pattern NUMBERED_LIST_PATTERN = Pattern.compile("^[\\s]*\\d+\\.\\s+(.+)$", Pattern.MULTILINE);
-    private static final Pattern CODE_BLOCK_PATTERN = Pattern.compile("```(\\w+)?\\n([\\s\\S]*?)```", Pattern.MULTILINE);
+    private static final List<Extension> EXTENSIONS = List.of(
+        TablesExtension.create(),
+        StrikethroughExtension.create(),
+        TaskListItemsExtension.create()
+    );
+
+    private static final Parser PARSER = Parser.builder().extensions(EXTENSIONS).build();
+
+    /** Notion only supports heading levels 1-3; deeper Markdown headings are clamped. */
+    private static final int MAX_HEADING_LEVEL = 3;
+
+    /** Notion's code-block "language" is a closed enum; an unknown value is rejected by the API. */
+    private static final Set<String> NOTION_CODE_LANGUAGES = Set.of(
+        "abap", "agda", "arduino", "ascii art", "assembly", "bash", "basic", "bnf", "c", "c#",
+        "c++", "clojure", "coffeescript", "coq", "css", "dart", "dhall", "diff", "docker", "ebnf",
+        "elixir", "elm", "erlang", "f#", "flow", "fortran", "gherkin", "glsl", "go", "graphql",
+        "groovy", "haskell", "hcl", "html", "idris", "java", "javascript", "json", "julia", "kotlin",
+        "latex", "less", "lisp", "livescript", "llvm ir", "lua", "makefile", "markdown", "markup",
+        "matlab", "mathematica", "mermaid", "nix", "notion formula", "objective-c", "ocaml", "pascal",
+        "perl", "php", "plain text", "powershell", "prolog", "protobuf", "purescript", "python", "r",
+        "racket", "reason", "ruby", "rust", "sass", "scala", "scheme", "scss", "shell", "smalltalk",
+        "solidity", "sql", "swift", "toml", "typescript", "vb.net", "verilog", "vhdl", "visual basic",
+        "webassembly", "xml", "yaml", "java/c/c++/c#"
+    );
+
+    /** Common Markdown fence tokens that differ from Notion's enum names. */
+    private static final Map<String, String> LANGUAGE_ALIASES = Map.ofEntries(
+        Map.entry("js", "javascript"), Map.entry("jsx", "javascript"), Map.entry("node", "javascript"),
+        Map.entry("ts", "typescript"), Map.entry("tsx", "typescript"), Map.entry("py", "python"),
+        Map.entry("rb", "ruby"), Map.entry("rs", "rust"), Map.entry("kt", "kotlin"),
+        Map.entry("cs", "c#"), Map.entry("cpp", "c++"), Map.entry("cxx", "c++"),
+        Map.entry("objc", "objective-c"), Map.entry("golang", "go"), Map.entry("sh", "shell"),
+        Map.entry("zsh", "shell"), Map.entry("yml", "yaml"), Map.entry("md", "markdown"),
+        Map.entry("dockerfile", "docker"), Map.entry("proto", "protobuf"), Map.entry("htm", "html"),
+        Map.entry("text", "plain text"), Map.entry("plain", "plain text"),
+        Map.entry("plaintext", "plain text"), Map.entry("txt", "plain text")
+    );
+
+    // =========================================================================
+    // Markdown -> Notion blocks
+    // =========================================================================
 
     /**
      * Convert markdown content to Notion blocks array
-     * 
+     *
      * @param markdown The markdown content to convert
      * @return Array of Notion blocks
      */
     public static ArrayNode markdownToBlocks(String markdown) {
+        ArrayNode blocks = mapper.createArrayNode();
+
         if (markdown == null || markdown.trim().isEmpty()) {
-            return mapper.createArrayNode();
+            return blocks;
         }
 
         logger.debug("Converting markdown to Notion blocks: {} chars", markdown.length());
 
-        ArrayNode blocks = mapper.createArrayNode();
-        String[] lines = markdown.split("\n");
-
-        boolean inCodeBlock = false;
-        StringBuilder codeBlockContent = new StringBuilder();
-        String codeBlockLanguage = null;
-
-        for (int i = 0; i < lines.length; i++) {
-            String line = lines[i];
-
-            // Handle code blocks
-            if (line.startsWith("```")) {
-                if (!inCodeBlock) {
-                    // Starting code block
-                    inCodeBlock = true;
-                    codeBlockLanguage = line.substring(3).trim();
-                    if (codeBlockLanguage.isEmpty()) {
-                        codeBlockLanguage = null;
-                    }
-                    codeBlockContent.setLength(0);
-                } else {
-                    // Ending code block
-                    inCodeBlock = false;
-                    blocks.add(createCodeBlock(codeBlockContent.toString(), codeBlockLanguage));
-                    codeBlockLanguage = null;
-                }
-                continue;
-            }
-
-            if (inCodeBlock) {
-                if (codeBlockContent.length() > 0) {
-                    codeBlockContent.append("\n");
-                }
-                codeBlockContent.append(line);
-                continue;
-            }
-
-            // Handle headers
-            if (line.startsWith("#")) {
-                blocks.add(createHeaderBlock(line));
-                continue;
-            }
-
-            // Handle list items
-            if (line.trim().matches("^[-*+]\\s+.+")) {
-                blocks.add(createBulletedListBlock(line));
-                continue;
-            }
-
-            if (line.trim().matches("^\\d+\\.\\s+.+")) {
-                blocks.add(createNumberedListBlock(line));
-                continue;
-            }
-
-            // Handle empty lines
-            if (line.trim().isEmpty()) {
-                continue;
-            }
-
-            // Handle paragraphs
-            blocks.add(createParagraphBlock(line));
+        Node document = PARSER.parse(markdown);
+        for (Node node = document.getFirstChild(); node != null; node = node.getNext()) {
+            appendBlock(blocks, node);
         }
 
         logger.debug("Created {} Notion blocks from markdown", blocks.size());
@@ -112,8 +126,305 @@ public class MarkdownConverter {
     }
 
     /**
+     * Map a single CommonMark block node to its Notion block(s) and append them to {@code out}.
+     */
+    private static void appendBlock(ArrayNode out, Node node) {
+        switch (node) {
+            case Heading heading -> out.add(headingBlock(heading));
+            case Paragraph paragraph -> out.add(wrapParagraph(inlineRichText(paragraph)));
+            case FencedCodeBlock code -> out.add(codeBlock(code.getLiteral(), code.getInfo()));
+            case IndentedCodeBlock code -> out.add(codeBlock(code.getLiteral(), null));
+            case BulletList list -> appendListItems(out, list, false);
+            case OrderedList list -> appendListItems(out, list, true);
+            case BlockQuote quote -> out.add(quoteBlock(quote));
+            case ThematicBreak thematicBreak -> out.add(block("divider", mapper.createObjectNode()));
+            case TableBlock table -> out.add(tableBlock(table));
+            default -> {
+                // Fallback: surface any inline content as a paragraph so nothing is silently dropped.
+                ArrayNode richText = inlineRichText(node);
+                if (!richText.isEmpty()) {
+                    out.add(wrapParagraph(richText));
+                }
+            }
+        }
+    }
+
+    private static void appendListItems(ArrayNode out, Node list, boolean ordered) {
+        for (Node item = list.getFirstChild(); item != null; item = item.getNext()) {
+            if (item instanceof ListItem listItem) {
+                out.add(listItemBlock(listItem, ordered));
+            }
+        }
+    }
+
+    /**
+     * Build a list item block. A {@code TaskListItemMarker} promotes the item to a Notion
+     * {@code to_do} block; nested lists/blocks under the item become Notion children.
+     */
+    private static ObjectNode listItemBlock(ListItem item, boolean ordered) {
+        Node first = item.getFirstChild();
+
+        // The task-list extension prepends a TaskListItemMarker as the list item's first child;
+        // its presence turns the item into a Notion to_do block.
+        TaskListItemMarker marker = null;
+        if (first instanceof TaskListItemMarker taskMarker) {
+            marker = taskMarker;
+            first = first.getNext();
+        }
+
+        ArrayNode richText;
+        Node childStart;
+        if (first instanceof Paragraph) {
+            richText = inlineRichText(first);
+            childStart = first.getNext();
+        } else {
+            richText = mapper.createArrayNode();
+            childStart = first;
+        }
+
+        ArrayNode children = mapper.createArrayNode();
+        for (Node child = childStart; child != null; child = child.getNext()) {
+            appendBlock(children, child);
+        }
+
+        String type = marker != null ? "to_do" : (ordered ? "numbered_list_item" : "bulleted_list_item");
+
+        ObjectNode body = mapper.createObjectNode();
+        body.set("rich_text", richText);
+        if (marker != null) {
+            body.put("checked", marker.isChecked());
+        }
+        if (!children.isEmpty()) {
+            body.set("children", children);
+        }
+
+        return block(type, body);
+    }
+
+    private static ObjectNode quoteBlock(BlockQuote quote) {
+        ArrayNode richText = mapper.createArrayNode();
+        ArrayNode children = mapper.createArrayNode();
+
+        Node first = quote.getFirstChild();
+        Node childStart = quote.getFirstChild();
+        if (first instanceof Paragraph) {
+            richText = inlineRichText(first);
+            childStart = first.getNext();
+        }
+        for (Node child = childStart; child != null; child = child.getNext()) {
+            appendBlock(children, child);
+        }
+
+        ObjectNode body = mapper.createObjectNode();
+        body.set("rich_text", richText);
+        if (!children.isEmpty()) {
+            body.set("children", children);
+        }
+        return block("quote", body);
+    }
+
+    private static ObjectNode tableBlock(TableBlock table) {
+        List<ArrayNode> rowCells = new ArrayList<>();
+        int width = 0;
+
+        // A TableBlock contains a TableHead and (optionally) a TableBody, each holding TableRows.
+        for (Node section = table.getFirstChild(); section != null; section = section.getNext()) {
+            for (Node row = section.getFirstChild(); row != null; row = row.getNext()) {
+                if (!(row instanceof TableRow)) {
+                    continue;
+                }
+                ArrayNode cells = mapper.createArrayNode();
+                for (Node cell = row.getFirstChild(); cell != null; cell = cell.getNext()) {
+                    if (cell instanceof TableCell) {
+                        cells.add(inlineRichText(cell));
+                    }
+                }
+                width = Math.max(width, cells.size());
+                rowCells.add(cells);
+            }
+        }
+
+        ArrayNode children = mapper.createArrayNode();
+        for (ArrayNode cells : rowCells) {
+            // Notion requires every row to have exactly table_width cells.
+            while (cells.size() < width) {
+                cells.add(mapper.createArrayNode());
+            }
+            ObjectNode rowBody = mapper.createObjectNode();
+            rowBody.set("cells", cells);
+            children.add(block("table_row", rowBody));
+        }
+
+        ObjectNode body = mapper.createObjectNode();
+        body.put("table_width", width);
+        body.put("has_column_header", true);
+        body.put("has_row_header", false);
+        body.set("children", children);
+        return block("table", body);
+    }
+
+    private static ObjectNode headingBlock(Heading heading) {
+        String type = "heading_" + Math.min(heading.getLevel(), MAX_HEADING_LEVEL);
+        ObjectNode body = mapper.createObjectNode();
+        body.set("rich_text", inlineRichText(heading));
+        return block(type, body);
+    }
+
+    private static ObjectNode wrapParagraph(ArrayNode richText) {
+        ObjectNode body = mapper.createObjectNode();
+        body.set("rich_text", richText);
+        return block("paragraph", body);
+    }
+
+    private static ObjectNode codeBlock(String content, String info) {
+        ObjectNode body = mapper.createObjectNode();
+
+        ArrayNode richText = mapper.createArrayNode();
+        addText(richText, stripTrailingNewline(content), Ctx.EMPTY);
+        body.set("rich_text", richText);
+
+        body.put("language", notionLanguage(info));
+
+        return block("code", body);
+    }
+
+    /**
+     * Resolve a Markdown fence info string to a value Notion's code-block language enum accepts.
+     * Notion rejects the whole request for an unknown language, so an unspecified or unrecognised fence
+     * (including common aliases like js/ts/yml) falls back to "plain text", the enum's neutral value.
+     */
+    private static String notionLanguage(String info) {
+        if (info == null || info.isBlank()) {
+            return "plain text";
+        }
+        String token = info.trim().split("\\s+")[0].toLowerCase(Locale.ROOT);
+        token = LANGUAGE_ALIASES.getOrDefault(token, token);
+        return NOTION_CODE_LANGUAGES.contains(token) ? token : "plain text";
+    }
+
+    private static String stripTrailingNewline(String s) {
+        if (s == null) {
+            return "";
+        }
+        return s.endsWith("\n") ? s.substring(0, s.length() - 1) : s;
+    }
+
+    private static ObjectNode block(String type, ObjectNode body) {
+        ObjectNode block = mapper.createObjectNode();
+        block.put("object", "block");
+        block.put("type", type);
+        block.set(type, body);
+        return block;
+    }
+
+    // ---- Inline rich text -------------------------------------------------
+
+    /**
+     * Build a Notion {@code rich_text} array from a block node's inline children.
+     */
+    private static ArrayNode inlineRichText(Node parent) {
+        ArrayNode out = mapper.createArrayNode();
+        collectInlines(parent, out, Ctx.EMPTY);
+        return out;
+    }
+
+    /**
+     * Walk inline nodes left-to-right, carrying annotation/link context down through
+     * nested emphasis and links so e.g. a bold link is both bold and a link.
+     */
+    private static void collectInlines(Node parent, ArrayNode out, Ctx ctx) {
+        for (Node child = parent.getFirstChild(); child != null; child = child.getNext()) {
+            switch (child) {
+                case Text text -> addText(out, text.getLiteral(), ctx);
+                case StrongEmphasis strong -> collectInlines(child, out, ctx.withBold());
+                case Emphasis emphasis -> collectInlines(child, out, ctx.withItalic());
+                case Strikethrough strikethrough -> collectInlines(child, out, ctx.withStrike());
+                case Code code -> addText(out, code.getLiteral(), ctx.withCode());
+                case Link link -> {
+                    String dest = link.getDestination();
+                    collectInlines(child, out, dest == null || dest.isBlank() ? ctx : ctx.withHref(dest));
+                }
+                case Image image -> collectInlines(child, out, ctx); // render alt-text inlines as plain text
+                case SoftLineBreak softBreak -> addText(out, "\n", ctx);
+                case HardLineBreak hardBreak -> addText(out, "\n", ctx);
+                case TaskListItemMarker marker -> {
+                    /* consumed at the list-item level */ }
+                default -> collectInlines(child, out, ctx); // unknown inline container: descend
+            }
+        }
+    }
+
+    private static void addText(ArrayNode out, String content, Ctx ctx) {
+        if (content == null || content.isEmpty()) {
+            return;
+        }
+
+        ObjectNode item = mapper.createObjectNode();
+        item.put("type", "text");
+
+        ObjectNode text = mapper.createObjectNode();
+        text.put("content", content);
+        if (ctx.href() != null) {
+            ObjectNode link = mapper.createObjectNode();
+            link.put("url", ctx.href());
+            text.set("link", link);
+        }
+        item.set("text", text);
+
+        if (ctx.href() != null) {
+            item.put("href", ctx.href());
+        }
+        item.set("annotations", annotations(ctx));
+
+        out.add(item);
+    }
+
+    private static ObjectNode annotations(Ctx ctx) {
+        ObjectNode annotations = mapper.createObjectNode();
+        annotations.put("bold", ctx.bold());
+        annotations.put("italic", ctx.italic());
+        annotations.put("strikethrough", ctx.strike());
+        annotations.put("underline", false);
+        annotations.put("code", ctx.code());
+        annotations.put("color", "default");
+        return annotations;
+    }
+
+    /**
+     * Immutable inline formatting context threaded through {@link #collectInlines}.
+     */
+    private record Ctx(boolean bold, boolean italic, boolean code, boolean strike, String href) {
+
+        static final Ctx EMPTY = new Ctx(false, false, false, false, null);
+
+        Ctx withBold() {
+            return new Ctx(true, italic, code, strike, href);
+        }
+
+        Ctx withItalic() {
+            return new Ctx(bold, true, code, strike, href);
+        }
+
+        Ctx withCode() {
+            return new Ctx(bold, italic, true, strike, href);
+        }
+
+        Ctx withStrike() {
+            return new Ctx(bold, italic, code, true, href);
+        }
+
+        Ctx withHref(String url) {
+            return new Ctx(bold, italic, code, strike, url);
+        }
+    }
+
+    // =========================================================================
+    // Notion blocks -> Markdown
+    // =========================================================================
+
+    /**
      * Convert Notion blocks to markdown content
-     * 
+     *
      * @param blocks The Notion blocks to convert
      * @return Markdown content
      */
@@ -237,199 +548,5 @@ public class MarkdownConverter {
         }
 
         return result.toString();
-    }
-
-    /**
-     * Create a paragraph block from markdown text
-     */
-    private static ObjectNode createParagraphBlock(String text) {
-        ObjectNode block = mapper.createObjectNode();
-        block.put("object", "block");
-        block.put("type", "paragraph");
-
-        ObjectNode paragraph = mapper.createObjectNode();
-        paragraph.set("rich_text", createRichTextFromMarkdown(text));
-        block.set("paragraph", paragraph);
-
-        return block;
-    }
-
-    /**
-     * Create a header block from markdown header line
-     */
-    private static ObjectNode createHeaderBlock(String headerLine) {
-        int level = 0;
-        for (char c : headerLine.toCharArray()) {
-            if (c == '#')
-                level++;
-            else
-                break;
-        }
-
-        String text = headerLine.substring(level).trim();
-        String blockType = "heading_" + Math.min(level, 3); // Notion supports heading_1, heading_2, heading_3
-
-        ObjectNode block = mapper.createObjectNode();
-        block.put("object", "block");
-        block.put("type", blockType);
-
-        ObjectNode heading = mapper.createObjectNode();
-        heading.set("rich_text", createRichTextFromMarkdown(text));
-        block.set(blockType, heading);
-
-        return block;
-    }
-
-    /**
-     * Create a bulleted list item block
-     */
-    private static ObjectNode createBulletedListBlock(String listLine) {
-        String text = listLine.trim().replaceFirst("^[-*+]\\s+", "");
-
-        ObjectNode block = mapper.createObjectNode();
-        block.put("object", "block");
-        block.put("type", "bulleted_list_item");
-
-        ObjectNode listItem = mapper.createObjectNode();
-        listItem.set("rich_text", createRichTextFromMarkdown(text));
-        block.set("bulleted_list_item", listItem);
-
-        return block;
-    }
-
-    /**
-     * Create a numbered list item block
-     */
-    private static ObjectNode createNumberedListBlock(String listLine) {
-        String text = listLine.trim().replaceFirst("^\\d+\\.\\s+", "");
-
-        ObjectNode block = mapper.createObjectNode();
-        block.put("object", "block");
-        block.put("type", "numbered_list_item");
-
-        ObjectNode listItem = mapper.createObjectNode();
-        listItem.set("rich_text", createRichTextFromMarkdown(text));
-        block.set("numbered_list_item", listItem);
-
-        return block;
-    }
-
-    /**
-     * Create a code block
-     */
-    private static ObjectNode createCodeBlock(String content, String language) {
-        ObjectNode block = mapper.createObjectNode();
-        block.put("object", "block");
-        block.put("type", "code");
-
-        ObjectNode code = mapper.createObjectNode();
-        code.set("rich_text", createRichTextArray(content));
-        if (language != null && !language.isEmpty()) {
-            code.put("language", language);
-        }
-        block.set("code", code);
-
-        return block;
-    }
-
-    /**
-     * Create rich text array from markdown text with basic formatting
-     */
-    private static ArrayNode createRichTextFromMarkdown(String text) {
-        var richText = mapper.createArrayNode();
-
-        if (text == null || text.isEmpty()) {
-            return richText;
-        }
-
-        var matcher = LINK_PATTERN.matcher(text);
-        var lastEnd = 0;
-
-        while (matcher.find()) {
-            if (matcher.start() > lastEnd) {
-                richText.add(createPlainRichTextItem(text.substring(lastEnd, matcher.start())));
-            }
-            var linkText = matcher.group(1);
-            var linkUrl = matcher.group(2);
-            richText.add(createLinkRichTextItem(linkText, linkUrl));
-            lastEnd = matcher.end();
-        }
-
-        if (lastEnd < text.length()) {
-            richText.add(createPlainRichTextItem(text.substring(lastEnd)));
-        }
-
-        return richText;
-    }
-
-    private static ObjectNode createPlainRichTextItem(String content) {
-        var item = mapper.createObjectNode();
-        item.put("type", "text");
-
-        var textObject = mapper.createObjectNode();
-        textObject.put("content", content);
-        item.set("text", textObject);
-
-        item.set("annotations", createDefaultAnnotations());
-        return item;
-    }
-
-    private static ObjectNode createLinkRichTextItem(String content, String url) {
-        var item = mapper.createObjectNode();
-        item.put("type", "text");
-
-        var textObject = mapper.createObjectNode();
-        textObject.put("content", content);
-        var linkObject = mapper.createObjectNode();
-        linkObject.put("url", url);
-        textObject.set("link", linkObject);
-        item.set("text", textObject);
-
-        item.put("href", url);
-        item.set("annotations", createDefaultAnnotations());
-        return item;
-    }
-
-    private static ObjectNode createDefaultAnnotations() {
-        var annotations = mapper.createObjectNode();
-        annotations.put("bold", false);
-        annotations.put("italic", false);
-        annotations.put("strikethrough", false);
-        annotations.put("underline", false);
-        annotations.put("code", false);
-        annotations.put("color", "default");
-        return annotations;
-    }
-
-    /**
-     * Create simple rich text array for plain text
-     */
-    private static ArrayNode createRichTextArray(String text) {
-        ArrayNode richText = mapper.createArrayNode();
-
-        if (text == null || text.isEmpty()) {
-            return richText;
-        }
-
-        ObjectNode richTextItem = mapper.createObjectNode();
-        richTextItem.put("type", "text");
-        richTextItem.put("plain_text", text);
-
-        ObjectNode textObject = mapper.createObjectNode();
-        textObject.put("content", text);
-        richTextItem.set("text", textObject);
-
-        ObjectNode annotations = mapper.createObjectNode();
-        annotations.put("bold", false);
-        annotations.put("italic", false);
-        annotations.put("strikethrough", false);
-        annotations.put("underline", false);
-        annotations.put("code", false);
-        annotations.put("color", "default");
-        richTextItem.set("annotations", annotations);
-
-        richText.add(richTextItem);
-
-        return richText;
     }
 }

--- a/src/test/java/io/kestra/plugin/notion/utils/MarkdownConverterTest.java
+++ b/src/test/java/io/kestra/plugin/notion/utils/MarkdownConverterTest.java
@@ -470,6 +470,205 @@ class MarkdownConverterTest {
     }
 
     // =========================
+    // Issue #56: GFM tables, inline formatting, backslash escapes
+    // =========================
+
+    @Test
+    void testGfmTableToBlocks() {
+        String markdown = """
+            | Feature | Value |
+            |---------|-------|
+            | Tables  | yes   |
+            | Bold    | also  |
+            """;
+
+        ArrayNode result = MarkdownConverter.markdownToBlocks(markdown);
+
+        assertThat(result.size(), equalTo(1));
+        JsonNode table = result.get(0);
+        assertThat(table.path("type").asText(), equalTo("table"));
+
+        JsonNode tableData = table.path("table");
+        assertThat(tableData.path("table_width").asInt(), equalTo(2));
+        assertThat(tableData.path("has_column_header").asBoolean(), equalTo(true));
+        assertThat(tableData.path("has_row_header").asBoolean(), equalTo(false));
+
+        JsonNode rows = tableData.path("children");
+        assertThat(rows.size(), equalTo(3)); // header + 2 body rows
+
+        JsonNode headerRow = rows.get(0);
+        assertThat(headerRow.path("type").asText(), equalTo("table_row"));
+        JsonNode headerCells = headerRow.path("table_row").path("cells");
+        assertThat(headerCells.size(), equalTo(2));
+        assertThat(headerCells.get(0).get(0).path("text").path("content").asText(), equalTo("Feature"));
+        assertThat(headerCells.get(1).get(0).path("text").path("content").asText(), equalTo("Value"));
+
+        JsonNode firstBodyCell = rows.get(1).path("table_row").path("cells").get(0).get(0);
+        assertThat(firstBodyCell.path("text").path("content").asText(), equalTo("Tables"));
+    }
+
+    @Test
+    void testInlineFormattingAnnotations() {
+        String markdown = "A paragraph with **bold**, *italic*, `code`, and ~~struck~~ text.";
+        ArrayNode result = MarkdownConverter.markdownToBlocks(markdown);
+
+        assertThat(result.size(), equalTo(1));
+        JsonNode richText = result.get(0).path("paragraph").path("rich_text");
+
+        assertThat(annotationFor(richText, "bold").path("bold").asBoolean(), equalTo(true));
+        assertThat(annotationFor(richText, "italic").path("italic").asBoolean(), equalTo(true));
+        assertThat(annotationFor(richText, "code").path("code").asBoolean(), equalTo(true));
+        assertThat(annotationFor(richText, "struck").path("strikethrough").asBoolean(), equalTo(true));
+    }
+
+    @Test
+    void testBoldLinkCombination() {
+        String markdown = "**[Kestra](https://kestra.io)**";
+        ArrayNode result = MarkdownConverter.markdownToBlocks(markdown);
+
+        JsonNode richText = result.get(0).path("paragraph").path("rich_text");
+        assertThat(richText.size(), equalTo(1));
+
+        JsonNode item = richText.get(0);
+        assertThat(item.path("text").path("content").asText(), equalTo("Kestra"));
+        assertThat(item.path("text").path("link").path("url").asText(), equalTo("https://kestra.io"));
+        assertThat(item.path("href").asText(), equalTo("https://kestra.io"));
+        assertThat(item.path("annotations").path("bold").asBoolean(), equalTo(true));
+    }
+
+    @Test
+    void testBackslashEscapesAreResolved() {
+        String markdown = "A price of \\$500 and a literal \\*asterisk\\*.";
+        ArrayNode result = MarkdownConverter.markdownToBlocks(markdown);
+
+        String text = concatRichText(result.get(0).path("paragraph").path("rich_text"));
+        assertThat(text, equalTo("A price of $500 and a literal *asterisk*."));
+        assertThat(text, not(containsString("\\")));
+    }
+
+    @Test
+    void testTaskListBecomesTodoBlocks() {
+        String markdown = "- [ ] Review proposal\n- [x] Schedule follow-up";
+        ArrayNode result = MarkdownConverter.markdownToBlocks(markdown);
+
+        assertThat(result.size(), equalTo(2));
+
+        JsonNode first = result.get(0);
+        assertThat(first.path("type").asText(), equalTo("to_do"));
+        assertThat(first.path("to_do").path("checked").asBoolean(), equalTo(false));
+        assertThat(concatRichText(first.path("to_do").path("rich_text")).trim(), equalTo("Review proposal"));
+
+        JsonNode second = result.get(1);
+        assertThat(second.path("type").asText(), equalTo("to_do"));
+        assertThat(second.path("to_do").path("checked").asBoolean(), equalTo(true));
+    }
+
+    @Test
+    void testCodeBlockWithoutLanguageDefaultsToPlainText() {
+        String markdown = "```\nsome code\n```";
+        ArrayNode result = MarkdownConverter.markdownToBlocks(markdown);
+
+        JsonNode code = result.get(0);
+        assertThat(code.path("type").asText(), equalTo("code"));
+        assertThat(code.path("code").path("language").asText(), equalTo("plain text"));
+    }
+
+    @Test
+    void testIssue56Repro() {
+        String markdown = """
+            ## Repro
+
+            A paragraph with **bold**, *italic*, `code`, a [link](https://kestra.io), and a price of \\$500.
+
+            | Feature | Value |
+            |---|---|
+            | Tables | should render |
+            | Bold   | **yes**       |
+            """;
+
+        ArrayNode result = MarkdownConverter.markdownToBlocks(markdown);
+
+        assertThat(blockTypes(result), hasItems("heading_2", "paragraph", "table"));
+
+        JsonNode paragraph = firstBlockOfType(result, "paragraph");
+        String paraText = concatRichText(paragraph.path("paragraph").path("rich_text"));
+        assertThat(paraText, containsString("$500")); // escape resolved
+        assertThat(paraText, not(containsString("\\$")));
+
+        JsonNode table = firstBlockOfType(result, "table");
+        assertThat(table.path("table").path("table_width").asInt(), equalTo(2));
+
+        // Bold inside a table cell carries the annotation.
+        JsonNode boldCell = table.path("table").path("children").get(2)
+            .path("table_row").path("cells").get(1).get(0);
+        assertThat(boldCell.path("text").path("content").asText(), equalTo("yes"));
+        assertThat(boldCell.path("annotations").path("bold").asBoolean(), equalTo(true));
+    }
+
+    @Test
+    void testCodeFenceLanguageAliasesMapToNotionEnum() {
+        assertThat(codeLanguage("```js\nx\n```"), equalTo("javascript"));
+        assertThat(codeLanguage("```ts\nx\n```"), equalTo("typescript"));
+        assertThat(codeLanguage("```yml\nx\n```"), equalTo("yaml"));
+        assertThat(codeLanguage("```Java\nx\n```"), equalTo("java"));
+    }
+
+    @Test
+    void testUnknownCodeFenceLanguageFallsBackToPlainText() {
+        assertThat(codeLanguage("```no-such-lang\nx\n```"), equalTo("plain text"));
+    }
+
+    private String codeLanguage(String markdown) {
+        return MarkdownConverter.markdownToBlocks(markdown).get(0).path("code").path("language").asText();
+    }
+
+    @Test
+    void testEmptyLinkDestinationRendersAsPlainText() {
+        ArrayNode result = MarkdownConverter.markdownToBlocks("see [here]() now");
+
+        JsonNode richText = result.get(0).path("paragraph").path("rich_text");
+        assertThat(concatRichText(richText), equalTo("see here now"));
+        for (JsonNode item : richText) {
+            assertThat(item.path("text").has("link"), equalTo(false));
+            assertThat(item.has("href"), equalTo(false));
+        }
+    }
+
+    private JsonNode annotationFor(JsonNode richText, String content) {
+        for (JsonNode item : richText) {
+            if (content.equals(item.path("text").path("content").asText())) {
+                return item.path("annotations");
+            }
+        }
+        throw new AssertionError("No rich text item with content: " + content);
+    }
+
+    private String concatRichText(JsonNode richText) {
+        StringBuilder sb = new StringBuilder();
+        for (JsonNode item : richText) {
+            sb.append(item.path("text").path("content").asText());
+        }
+        return sb.toString();
+    }
+
+    private java.util.List<String> blockTypes(ArrayNode blocks) {
+        java.util.List<String> types = new java.util.ArrayList<>();
+        for (JsonNode block : blocks) {
+            types.add(block.path("type").asText());
+        }
+        return types;
+    }
+
+    private JsonNode firstBlockOfType(ArrayNode blocks, String type) {
+        for (JsonNode block : blocks) {
+            if (type.equals(block.path("type").asText())) {
+                return block;
+            }
+        }
+        throw new AssertionError("No block of type: " + type);
+    }
+
+    // =========================
     // Helper Methods for Test Data Creation
     // =========================
 


### PR DESCRIPTION
## What

Fixes #56. `page.Create`, `page.Update` and `database.CreateItem` document `content` as Markdown "rendered to Notion blocks", but several common features were passed through as literal text: GFM tables, inline formatting (**bold**, *italic*, `code`, [links]), ~~strikethrough~~, task lists, and backslash escapes (`\$500` showed the backslash). Notion's API supports all of these, so this was a converter gap, not an API limit.

## Why not a smaller fix

The tempting patch is "add a few more regexes" — but that's how we got here. The converter hand-rolled Markdown parsing, links were bolted on separately in #33, and it still shipped broken tables/emphasis/escapes. Inline Markdown is a long tail of edge cases by hand, so this replaces the parser instead of extending it: parse with the CommonMark reference parser (commonmark-java + GFM tables/strikethrough/task-list extensions) and walk the AST into Notion blocks. The only code we own is the Notion-specific mapping. The reverse path (`blocksToMarkdown`, used by `page.Read`) is unchanged.

## The diff is smaller than it looks

`MarkdownConverter.java` is net ~+76 lines — ~262 lines of brittle line-scanning and regex are deleted and replaced by a declarative AST walk. The rest is tests (pure additions) plus an ~85-entry Notion language enum.

## Notes

Code-fence languages are validated against Notion's code-block language enum (common aliases such as js→javascript and yml→yaml are mapped), falling back to "plain text" for unspecified or unknown languages, which the API requires. Links with an empty destination render as plain text instead of an invalid empty URL. The new dependency (~300 KB, no transitive deps) is bundled via the existing shadowJar, matching how Kestra plugins ship libraries. The same converter also serves `database.CreateItem`, and the `- [ ]` task lists in `page.Create`'s own example now render.

## Testing

Full suite green — 140 tests (3 pre-existing skips). Verified end-to-end against the live Notion API on a local Kestra (`server local`): table, inline formatting, link, $500, checkboxes, quote, and a js→javascript code block all render correctly.

<img width="500" alt="Screenshot 2026-06-25 at 16 25 29" src="https://github.com/user-attachments/assets/845cc7de-f116-430d-be51-101212adfb63" />


## Out of scope

Notion's [per-request limits](https://github.com/kestra-io/plugin-notion/issues/57) (100 blocks, 2000 chars/rich-text, ~2-level nesting) aren't enforced here — pre-existing, tracked as a follow-up. Extending the reverse path (`blocksToMarkdown`) to the new block types is also out of scope.
