### PR TITLE
build(deps): bump gradle wrapper, plugins and slf4j

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 plugins {
-    id 'io.kestra.gradle.spotless-conventions' version '1.1.0'
-    id "com.vanniktech.maven.publish" version "0.36.0"
+    id 'io.kestra.gradle.spotless-conventions' version '1.2.1'
+    id "com.vanniktech.maven.publish" version "0.37.0"
     id 'java-library'
     id "idea"
     id 'jacoco'
     id "com.adarshr.test-logger" version "4.0.0"
-    id "com.gradleup.shadow" version "9.4.1"
+    id "com.gradleup.shadow" version "9.4.2"
     id 'signing'
     id "com.github.ben-manes.versions" version "0.54.0"
     id 'net.researchgate.release' version '3.1.0'
@@ -47,7 +47,7 @@ dependencies {
     annotationProcessor group: "io.kestra", name: "processor", version: kestraVersion
 
     // Logs
-    compileOnly 'org.slf4j:slf4j-api:2.0.17'
+    compileOnly 'org.slf4j:slf4j-api:2.0.18'
 
     // Markdown parsing (CommonMark + GFM tables/strikethrough/task-lists), bundled into the plugin jar via shadowJar
     implementation 'org.commonmark:commonmark:0.29.0'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
Consolidates all open Dependabot dependency PRs into one.

- gradle-wrapper 9.5.0 -> 9.6.0 (closes #55)
- com.vanniktech.maven.publish 0.36.0 -> 0.37.0 (closes #54)
- io.kestra.gradle.spotless-conventions 1.1.0 -> 1.2.1 (closes #53)
- com.gradleup.shadow 9.4.1 -> 9.4.2 (closes #51)
- org.slf4j:slf4j-api 2.0.17 -> 2.0.18 (closes #47)

`./gradlew compileJava` passes.