### PR TITLE
fix(notion): paginate block payloads to Notion's 100-block limit

### DIFF
--- a/src/main/java/io/kestra/plugin/notion/NotionConnection.java
+++ b/src/main/java/io/kestra/plugin/notion/NotionConnection.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.http.HttpRequest;
@@ -57,6 +58,9 @@ public abstract class NotionConnection extends Task {
     public static final String PAGES_ENDPOINT = "/v1/pages";
     public static final String BLOCKS_ENDPOINT = "/v1/blocks";
     public static final String SEARCH_ENDPOINT = "/v1/search";
+
+    /** Notion caps a single create/append request at 100 child blocks. */
+    public static final int MAX_BLOCKS_PER_REQUEST = 100;
 
     @Schema(
         title = "Notion API token",
@@ -186,6 +190,46 @@ public abstract class NotionConnection extends Task {
 
         getAuthorizedRequest(runContext, requestBuilder);
         return requestBuilder;
+    }
+
+    /**
+     * Splits a block array into batches of at most {@link #MAX_BLOCKS_PER_REQUEST} and appends each
+     * batch, in order, to a page/block via the children endpoint. Notion caps a single request at 100
+     * child blocks, so longer content must be paginated.
+     *
+     * @param startIndex index of the first block to append — {@link #MAX_BLOCKS_PER_REQUEST} when the
+     *        first batch was already sent inline with a create request, or 0 to append all
+     */
+    protected void appendBlocksInBatches(RunContext runContext, String blockId, ArrayNode blocks, int startIndex) throws Exception {
+        if (blocks == null) {
+            return;
+        }
+        var url = buildPageChildrenURL(blockId);
+        for (var i = Math.max(startIndex, 0); i < blocks.size(); i += MAX_BLOCKS_PER_REQUEST) {
+            var batch = mapper.createArrayNode();
+            var end = Math.min(i + MAX_BLOCKS_PER_REQUEST, blocks.size());
+            for (var j = i; j < end; j++) {
+                batch.add(blocks.get(j));
+            }
+            var requestBuilder = buildPatchRequest(runContext, url, Map.of("children", batch));
+            makeCall(runContext, requestBuilder, NotionResponse.class);
+        }
+    }
+
+    /**
+     * Returns the first {@link #MAX_BLOCKS_PER_REQUEST} blocks (or fewer) for inclusion in a
+     * page-creation request; the remainder should be appended via
+     * {@link #appendBlocksInBatches(RunContext, String, ArrayNode, int)}.
+     */
+    protected ArrayNode firstBlockBatch(ArrayNode blocks) {
+        var batch = mapper.createArrayNode();
+        if (blocks != null) {
+            var end = Math.min(MAX_BLOCKS_PER_REQUEST, blocks.size());
+            for (var i = 0; i < end; i++) {
+                batch.add(blocks.get(i));
+            }
+        }
+        return batch;
     }
 
     /**

--- a/src/main/java/io/kestra/plugin/notion/database/CreateItem.java
+++ b/src/main/java/io/kestra/plugin/notion/database/CreateItem.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
@@ -22,7 +23,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -88,7 +88,8 @@ public class CreateItem extends AbstractDatabaseTask implements RunnableTask<Cre
         title = "Content",
         description = """
             Optional markdown content appended as paragraph blocks to the page body.
-            Note that the Notion API enforces a limit of 2000 characters per [rich text content block](https://developers.notion.com/reference/request-limits)."""
+            Note that the Notion API enforces a limit of 2000 characters per [rich text content block](https://developers.notion.com/reference/request-limits).
+            Content over 100 blocks is sent across multiple requests (Notion caps a request at 100 blocks); this is not atomic, so a retry may leave a partially-filled or duplicate item."""
     )
     @PluginProperty(group = "advanced")
     private Property<String> content;
@@ -112,27 +113,35 @@ public class CreateItem extends AbstractDatabaseTask implements RunnableTask<Cre
         // properties rendered from Pebble expressions are sent as JSON booleans, not strings.
         var rProperties = new HashMap<String, Object>(
             runContext.render(this.properties).asMap(String.class, Object.class).entrySet().stream()
-                .collect(Collectors.toMap(
-                    Map.Entry::getKey,
-                    e -> coerceBooleans(e.getValue())
-                ))
+                .collect(
+                    Collectors.toMap(
+                        Map.Entry::getKey,
+                        e -> coerceBooleans(e.getValue())
+                    )
+                )
         );
 
         // Set title property (Notion databases use a "title" typed property, usually named "Name")
-        rProperties.put("Name", Map.of(
-            "title", List.of(
-                Map.of(
-                    "type", "text",
-                    "text", Map.of("content", rTitle)
+        rProperties.put(
+            "Name", Map.of(
+                "title", List.of(
+                    Map.of(
+                        "type", "text",
+                        "text", Map.of("content", rTitle)
+                    )
                 )
             )
-        ));
+        );
         body.put("properties", rProperties);
 
-        // Content blocks
+        // Content blocks — first <=100 inline; any beyond that are appended after creation.
         var rContent = runContext.render(this.content).as(String.class).orElse(null);
-        if (rContent != null && !rContent.isBlank()) {
-            body.put("children", MarkdownConverter.markdownToBlocks(rContent));
+        var blocks = rContent != null && !rContent.isBlank()
+            ? MarkdownConverter.markdownToBlocks(rContent)
+            : null;
+        var firstBatch = firstBlockBatch(blocks);
+        if (!firstBatch.isEmpty()) {
+            body.put("children", firstBatch);
         }
 
         var url = getBaseUrl() + PAGES_ENDPOINT;
@@ -140,6 +149,8 @@ public class CreateItem extends AbstractDatabaseTask implements RunnableTask<Cre
 
         var requestBuilder = buildPostRequest(runContext, url, body);
         var response = makeCall(runContext, requestBuilder, NotionResponse.class);
+
+        appendBlocksInBatches(runContext, response.getId(), blocks, firstBatch.size());
 
         logger.info("Created database item with ID: {}", response.getId());
 

--- a/src/main/java/io/kestra/plugin/notion/database/CreateItem.java
+++ b/src/main/java/io/kestra/plugin/notion/database/CreateItem.java
@@ -89,7 +89,7 @@ public class CreateItem extends AbstractDatabaseTask implements RunnableTask<Cre
         description = """
             Optional markdown content appended as paragraph blocks to the page body.
             Note that the Notion API enforces a limit of 2000 characters per [rich text content block](https://developers.notion.com/reference/request-limits).
-            Content over 100 blocks is sent across multiple requests (Notion caps a request at 100 blocks); this is not atomic, so a retry may leave a partially-filled or duplicate item."""
+            Content over 100 blocks is sent across multiple requests (Notion caps a request at 100 blocks); this is not atomic, so a retry may leave a partially-filled or duplicate item. Very large content sends many requests in quick succession and may hit Notion's rate limit. A single block with more than 100 children (e.g. a large table) still exceeds Notion's limit, so only the top-level block list is paginated."""
     )
     @PluginProperty(group = "advanced")
     private Property<String> content;

--- a/src/main/java/io/kestra/plugin/notion/page/Create.java
+++ b/src/main/java/io/kestra/plugin/notion/page/Create.java
@@ -3,9 +3,12 @@ package io.kestra.plugin.notion.page;
 import java.time.Instant;
 import java.util.*;
 
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
 import io.kestra.core.http.HttpRequest;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
@@ -21,7 +24,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -97,7 +99,8 @@ public class Create extends NotionConnection implements RunnableTask<Create.Outp
         title = "Page content",
         description = """
             Optional markdown content converted to Notion blocks; empty leaves the page body blank.
-            Note that the Notion API enforces a limit of 2000 characters per [rich text content block](https://developers.notion.com/reference/request-limits)."""
+            Note that the Notion API enforces a limit of 2000 characters per [rich text content block](https://developers.notion.com/reference/request-limits).
+            Content over 100 blocks is sent across multiple requests (Notion caps a request at 100 blocks); this is not atomic, so a retry may leave a partially-filled or duplicate page."""
     )
     @PluginProperty(group = "advanced")
     private Property<String> content;
@@ -119,6 +122,11 @@ public class Create extends NotionConnection implements RunnableTask<Create.Outp
         );
 
         String renderedContent = runContext.render(this.content).as(String.class).orElse(null);
+        var blocks = renderedContent != null && !renderedContent.isEmpty()
+            ? MarkdownConverter.markdownToBlocks(renderedContent)
+            : null;
+        // First <=100 blocks go inline with the create; the remainder is appended afterwards.
+        var firstBatch = firstBlockBatch(blocks);
 
         String renderedParentPageId = runContext.render(this.parentPageId).as(String.class).orElse(null);
         if (renderedParentPageId != null && !renderedParentPageId.isEmpty()) {
@@ -132,7 +140,7 @@ public class Create extends NotionConnection implements RunnableTask<Create.Outp
         }
 
         // Build the request body
-        Map<String, Object> requestBody = buildCreatePageRequest(renderedTitle, renderedContent, renderedParentPageId);
+        Map<String, Object> requestBody = buildCreatePageRequest(renderedTitle, firstBatch, renderedParentPageId);
 
         // Make the API call
         String url = buildCreatePageURL();
@@ -142,6 +150,9 @@ public class Create extends NotionConnection implements RunnableTask<Create.Outp
         logger.debug("Request body: {}", mapper.writeValueAsString(requestBody));
 
         NotionResponse response = makeCall(runContext, requestBuilder, NotionResponse.class);
+
+        // Append the blocks that didn't fit in the create request (Notion caps a request at 100 blocks).
+        appendBlocksInBatches(runContext, response.getId(), blocks, firstBatch.size());
 
         return Output.builder()
             .pageId(response.getId())
@@ -159,7 +170,7 @@ public class Create extends NotionConnection implements RunnableTask<Create.Outp
     /**
      * Builds the request body for creating a Notion page
      */
-    private Map<String, Object> buildCreatePageRequest(String title, String content, String parentPageId) {
+    private Map<String, Object> buildCreatePageRequest(String title, ArrayNode firstBatch, String parentPageId) {
         Map<String, Object> requestBody = new HashMap<>();
 
         // Set parent (either a page or workspace)
@@ -187,9 +198,9 @@ public class Create extends NotionConnection implements RunnableTask<Create.Outp
         properties.put("title", titleProperty);
         requestBody.put("properties", properties);
 
-        // Convert markdown content to Notion blocks
-        if (content != null && !content.isEmpty()) {
-            requestBody.put("children", MarkdownConverter.markdownToBlocks(content));
+        // First batch of content blocks (<=100); any beyond that are appended after the page is created.
+        if (firstBatch != null && !firstBatch.isEmpty()) {
+            requestBody.put("children", firstBatch);
         }
 
         return requestBody;

--- a/src/main/java/io/kestra/plugin/notion/page/Create.java
+++ b/src/main/java/io/kestra/plugin/notion/page/Create.java
@@ -100,7 +100,7 @@ public class Create extends NotionConnection implements RunnableTask<Create.Outp
         description = """
             Optional markdown content converted to Notion blocks; empty leaves the page body blank.
             Note that the Notion API enforces a limit of 2000 characters per [rich text content block](https://developers.notion.com/reference/request-limits).
-            Content over 100 blocks is sent across multiple requests (Notion caps a request at 100 blocks); this is not atomic, so a retry may leave a partially-filled or duplicate page."""
+            Content over 100 blocks is sent across multiple requests (Notion caps a request at 100 blocks); this is not atomic, so a retry may leave a partially-filled or duplicate page. Very large content sends many requests in quick succession and may hit Notion's rate limit. A single block with more than 100 children (e.g. a large table) still exceeds Notion's limit, so only the top-level block list is paginated."""
     )
     @PluginProperty(group = "advanced")
     private Property<String> content;

--- a/src/main/java/io/kestra/plugin/notion/page/Update.java
+++ b/src/main/java/io/kestra/plugin/notion/page/Update.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import io.kestra.core.http.HttpRequest;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.notion.NotionResponse;
@@ -18,7 +19,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -95,7 +95,8 @@ public class Update extends AbstractTask {
         title = "New page content",
         description = """
             The new content for the page in markdown format. This will be appended to the bottom of the page.
-            Note that the Notion API enforces a limit of 2000 characters per [rich text content block](https://developers.notion.com/reference/request-limits)."""
+            Note that the Notion API enforces a limit of 2000 characters per [rich text content block](https://developers.notion.com/reference/request-limits).
+            Content over 100 blocks is appended across multiple requests (Notion caps a request at 100 blocks); a retry re-appends and may duplicate content."""
     )
     @PluginProperty(group = "advanced")
     private Property<String> content;
@@ -204,12 +205,8 @@ public class Update extends AbstractTask {
      * Adds new blocks to a page
      */
     protected void addBlocksToPage(RunContext runContext, String pageId, ArrayNode blocks) throws Exception {
-        Map<String, Object> requestBody = Map.of("children", blocks);
-
-        String url = buildPageChildrenURL(pageId);
-        HttpRequest.HttpRequestBuilder requestBuilder = buildPatchRequest(runContext, url, requestBody);
-
-        makeCall(runContext, requestBuilder, NotionResponse.class);
+        // Append in batches of at most MAX_BLOCKS_PER_REQUEST (Notion caps a single request at 100 blocks).
+        appendBlocksInBatches(runContext, pageId, blocks, 0);
     }
 
     @Override

--- a/src/main/java/io/kestra/plugin/notion/page/Update.java
+++ b/src/main/java/io/kestra/plugin/notion/page/Update.java
@@ -96,7 +96,7 @@ public class Update extends AbstractTask {
         description = """
             The new content for the page in markdown format. This will be appended to the bottom of the page.
             Note that the Notion API enforces a limit of 2000 characters per [rich text content block](https://developers.notion.com/reference/request-limits).
-            Content over 100 blocks is appended across multiple requests (Notion caps a request at 100 blocks); a retry re-appends and may duplicate content."""
+            Content over 100 blocks is appended across multiple requests (Notion caps a request at 100 blocks); a retry re-appends and may duplicate content. Very large content sends many requests in quick succession and may hit Notion's rate limit. A single block with more than 100 children (e.g. a large table) still exceeds Notion's limit, so only the top-level block list is paginated."""
     )
     @PluginProperty(group = "advanced")
     private Property<String> content;

--- a/src/test/java/io/kestra/plugin/notion/NotionConnectionTest.java
+++ b/src/test/java/io/kestra/plugin/notion/NotionConnectionTest.java
@@ -148,4 +148,25 @@ class NotionConnectionTest {
         assertThat(connectionWithConfig, notNullValue());
         assertThat(connectionWithConfig.getOptions(), nullValue());
     }
+
+    @Test
+    void testFirstBlockBatchCapsAtMaxBlocksPerRequest() {
+        var mapper = io.kestra.core.serializers.JacksonMapper.ofJson();
+
+        var many = mapper.createArrayNode();
+        for (int i = 0; i < 150; i++) {
+            many.add(mapper.createObjectNode().put("i", i));
+        }
+        assertThat(NotionConnection.MAX_BLOCKS_PER_REQUEST, equalTo(100));
+        assertThat(connection.firstBlockBatch(many).size(), equalTo(NotionConnection.MAX_BLOCKS_PER_REQUEST));
+
+        var few = mapper.createArrayNode();
+        for (int i = 0; i < 50; i++) {
+            few.add(mapper.createObjectNode().put("i", i));
+        }
+        assertThat(connection.firstBlockBatch(few).size(), equalTo(50));
+
+        assertThat(connection.firstBlockBatch(mapper.createArrayNode()).size(), equalTo(0));
+        assertThat(connection.firstBlockBatch(null).size(), equalTo(0));
+    }
 }

--- a/src/test/java/io/kestra/plugin/notion/database/CreateItemTest.java
+++ b/src/test/java/io/kestra/plugin/notion/database/CreateItemTest.java
@@ -4,32 +4,31 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
-import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.serializers.JacksonMapper;
 
 import jakarta.inject.Inject;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.patch;
+import static com.github.tomakehurst.wiremock.client.WireMock.patchRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @KestraTest
@@ -126,8 +125,10 @@ class CreateItemTest {
         assertThat(output.getPageId(), equalTo(PAGE_ID));
 
         // Verify the request body contained a "children" key
-        wireMockServer.verify(postRequestedFor(urlEqualTo("/v1/pages"))
-            .withRequestBody(com.github.tomakehurst.wiremock.client.WireMock.containing("\"children\"")));
+        wireMockServer.verify(
+            postRequestedFor(urlEqualTo("/v1/pages"))
+                .withRequestBody(com.github.tomakehurst.wiremock.client.WireMock.containing("\"children\""))
+        );
     }
 
     @Test
@@ -160,10 +161,12 @@ class CreateItemTest {
         responseBody.put("last_edited_time", "2024-06-15T11:00:00Z");
         responseBody.put("archived", false);
         responseBody.put("url", "https://www.notion.so/My-Page-" + PAGE_ID);
-        responseBody.put("properties", Map.of(
-            "Name", Map.of("title", List.of(Map.of("plain_text", "Test Item"))),
-            "Status", Map.of("select", Map.of("name", "To Do"))
-        ));
+        responseBody.put(
+            "properties", Map.of(
+                "Name", Map.of("title", List.of(Map.of("plain_text", "Test Item"))),
+                "Status", Map.of("select", Map.of("name", "To Do"))
+            )
+        );
 
         wireMockServer.stubFor(
             post(urlEqualTo("/v1/pages"))
@@ -235,9 +238,9 @@ class CreateItemTest {
         var runContext = runContextFactory.of(Map.of());
 
         // "true" and "false" as Strings, exactly as Pebble would produce them
-        var properties = Map.<String, Object>of(
-            "Done",   Map.<String, Object>of("checkbox", "true"),
-            "Active", Map.<String, Object>of("checkbox", "false")
+        var properties = Map.<String, Object> of(
+            "Done", Map.<String, Object> of("checkbox", "true"),
+            "Active", Map.<String, Object> of("checkbox", "false")
         );
 
         var createItem = CreateItem.builder()
@@ -262,6 +265,68 @@ class CreateItemTest {
         assertThat(body, org.hamcrest.Matchers.not(org.hamcrest.Matchers.containsString("\"checkbox\":\"false\"")));
     }
 
+    @Test
+    void createItem_with100Blocks_isSingleRequest() throws Exception {
+        // <=100 blocks must stay a single create request, with no append (no behaviour change).
+        var captured = runCreateItemCapturingRequests(100);
+        assertThat(captured.posts(), equalTo(1));
+        assertThat(captured.createChildren(), equalTo(100));
+        assertThat(captured.patches(), equalTo(0));
+    }
+
+    @Test
+    void createItem_with101Blocks_appendsTheOverflow() throws Exception {
+        // Boundary: the 101st block must be appended in exactly one follow-up request (not dropped).
+        var captured = runCreateItemCapturingRequests(101);
+        assertThat(captured.createChildren(), equalTo(100));
+        assertThat(captured.patches(), equalTo(1));
+    }
+
+    @Test
+    void createItem_with150Blocks_splitsIntoCreatePlusAppend() throws Exception {
+        var captured = runCreateItemCapturingRequests(150);
+        assertThat(captured.createChildren(), equalTo(100));
+        assertThat(captured.patches(), equalTo(1));
+    }
+
+    private record CreateItemCapture(int posts, int createChildren, int patches) {
+    }
+
+    private CreateItemCapture runCreateItemCapturingRequests(int blockCount) throws Exception {
+        stubCreatePage(PAGE_ID, false);
+        wireMockServer.stubFor(
+            patch(urlEqualTo("/v1/blocks/" + PAGE_ID + "/children"))
+                .willReturn(
+                    aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"object\":\"list\",\"results\":[]}")
+                        .withStatus(200)
+                )
+        );
+
+        var content = new StringBuilder();
+        for (int i = 0; i < blockCount; i++) {
+            content.append("## Section ").append(i).append("\n\n");
+        }
+
+        var runContext = runContextFactory.of(Map.of());
+
+        CreateItem.builder()
+            .apiToken(Property.ofValue("test-token"))
+            .databaseId(Property.ofValue(DATABASE_ID))
+            .title(Property.ofValue("Pagination"))
+            .content(Property.ofValue(content.toString()))
+            .build()
+            .run(runContext);
+
+        var posts = wireMockServer.findAll(postRequestedFor(urlEqualTo("/v1/pages")));
+        var patches = wireMockServer.findAll(patchRequestedFor(urlEqualTo("/v1/blocks/" + PAGE_ID + "/children")));
+        var createChildren = posts.isEmpty()
+            ? 0
+            : mapper.readTree(posts.getFirst().getBodyAsString()).path("children").size();
+        return new CreateItemCapture(posts.size(), createChildren, patches.size());
+    }
+
     // --- Helper ---
 
     private void stubCreatePage(String pageId, boolean archived) throws Exception {
@@ -272,9 +337,11 @@ class CreateItemTest {
         responseBody.put("last_edited_time", "2024-01-01T00:00:00Z");
         responseBody.put("archived", archived);
         responseBody.put("url", "https://www.notion.so/" + pageId);
-        responseBody.put("properties", Map.of(
-            "Name", Map.of("title", List.of(Map.of("plain_text", "Test Item")))
-        ));
+        responseBody.put(
+            "properties", Map.of(
+                "Name", Map.of("title", List.of(Map.of("plain_text", "Test Item")))
+            )
+        );
 
         wireMockServer.stubFor(
             post(urlEqualTo("/v1/pages"))

--- a/src/test/java/io/kestra/plugin/notion/page/CreateTest.java
+++ b/src/test/java/io/kestra/plugin/notion/page/CreateTest.java
@@ -1,11 +1,29 @@
 package io.kestra.plugin.notion.page;
 
+import java.util.Map;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+
+import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.serializers.JacksonMapper;
 import io.kestra.plugin.notion.NotionConnection;
 
+import jakarta.inject.Inject;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.patch;
+import static com.github.tomakehurst.wiremock.client.WireMock.patchRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -15,7 +33,13 @@ import static org.junit.jupiter.api.Assertions.*;
  * These tests focus on input validation, builder patterns, and request building
  * without requiring actual API calls.
  */
+@KestraTest
 class CreateTest {
+
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    private static final ObjectMapper mapper = JacksonMapper.ofJson(false);
 
     private Create create;
 
@@ -157,5 +181,99 @@ class CreateTest {
         assertThat(task.getTitle(), notNullValue());
         assertThat(task.getContent(), notNullValue());
         assertThat(task.getParentPageId(), notNullValue());
+    }
+
+    @Test
+    void testCreateWith100BlocksIsSingleRequest() throws Exception {
+        // <=100 blocks must stay a single create request, with no append (no behaviour change).
+        var captured = runCreateCapturingRequests(100);
+        assertThat(captured.posts(), equalTo(1));
+        assertThat(captured.createChildren(), equalTo(100));
+        assertThat(captured.patches(), equalTo(0));
+    }
+
+    @Test
+    void testCreateWith101BlocksAppendsTheOverflow() throws Exception {
+        // Boundary: the 101st block must be appended in exactly one follow-up request (not dropped).
+        var captured = runCreateCapturingRequests(101);
+        assertThat(captured.createChildren(), equalTo(100));
+        assertThat(captured.patches(), equalTo(1));
+    }
+
+    @Test
+    void testCreateWith150BlocksSplitsIntoCreatePlusAppend() throws Exception {
+        var captured = runCreateCapturingRequests(150);
+        assertThat(captured.createChildren(), equalTo(100));
+        assertThat(captured.patches(), equalTo(1));
+    }
+
+    private record CreateCapture(int posts, int createChildren, int patches) {
+    }
+
+    /**
+     * Runs {@link Create} with {@code blockCount} paragraph blocks against a stubbed Notion API and
+     * reports how the payload was split: number of create POSTs, the children the create carried, and
+     * the number of append PATCHes.
+     */
+    private CreateCapture runCreateCapturingRequests(int blockCount) throws Exception {
+        var newPageId = "12345678-1234-1234-1234-123456789abc";
+
+        var content = new StringBuilder();
+        for (int i = 0; i < blockCount; i++) {
+            content.append("Line ").append(i).append("\n\n");
+        }
+
+        var runContext = runContextFactory.of(Map.of());
+
+        var wireMockServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        wireMockServer.start();
+
+        var previousBaseUrl = System.getProperty("notion.api.base.url");
+        System.setProperty("notion.api.base.url", wireMockServer.baseUrl());
+
+        try {
+            configureFor("localhost", wireMockServer.port());
+
+            wireMockServer.stubFor(
+                post(urlEqualTo("/v1/pages"))
+                    .willReturn(
+                        aResponse()
+                            .withHeader("Content-Type", "application/json")
+                            .withBody("{\"object\":\"page\",\"id\":\"" + newPageId + "\"}")
+                            .withStatus(200)
+                    )
+            );
+
+            wireMockServer.stubFor(
+                patch(urlEqualTo("/v1/blocks/" + newPageId + "/children"))
+                    .willReturn(
+                        aResponse()
+                            .withHeader("Content-Type", "application/json")
+                            .withBody("{\"object\":\"list\",\"results\":[]}")
+                            .withStatus(200)
+                    )
+            );
+
+            Create.builder()
+                .apiToken(Property.ofValue("secret_token"))
+                .title(Property.ofValue("Batched"))
+                .content(Property.ofValue(content.toString()))
+                .build()
+                .run(runContext);
+
+            var posts = wireMockServer.findAll(postRequestedFor(urlEqualTo("/v1/pages")));
+            var patches = wireMockServer.findAll(patchRequestedFor(urlEqualTo("/v1/blocks/" + newPageId + "/children")));
+            var createChildren = posts.isEmpty()
+                ? 0
+                : mapper.readTree(posts.get(0).getBodyAsString()).path("children").size();
+            return new CreateCapture(posts.size(), createChildren, patches.size());
+        } finally {
+            wireMockServer.stop();
+            if (previousBaseUrl == null) {
+                System.clearProperty("notion.api.base.url");
+            } else {
+                System.setProperty("notion.api.base.url", previousBaseUrl);
+            }
+        }
     }
 }

--- a/src/test/java/io/kestra/plugin/notion/page/UpdateTest.java
+++ b/src/test/java/io/kestra/plugin/notion/page/UpdateTest.java
@@ -28,8 +28,10 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.patch;
+import static com.github.tomakehurst.wiremock.client.WireMock.patchRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -346,6 +348,69 @@ class UpdateTest {
             assertTrue(initialPos >= 0, "Initial Content not found in final markdown");
             assertTrue(appendedPos >= 0, "Appended Section not found in final markdown");
             assertTrue(appendedPos > initialPos, "Appended content should appear after initial content (append behavior)");
+        } finally {
+            wireMockServer.stop();
+            if (previousBaseUrl == null) {
+                System.clearProperty("notion.api.base.url");
+            } else {
+                System.setProperty("notion.api.base.url", previousBaseUrl);
+            }
+        }
+    }
+
+    @Test
+    void testUpdateSplitsContentOver100BlocksIntoBatches() throws Exception {
+        String apiToken = "secret_token";
+        String pageId = "12345678-1234-1234-1234-123456789abc";
+        String title = "Batched";
+
+        // 150 paragraphs -> 150 blocks -> must be appended as 100 + 50 across two requests, not one.
+        StringBuilder content = new StringBuilder();
+        for (int i = 0; i < 150; i++) {
+            content.append("Line ").append(i).append("\n\n");
+        }
+
+        RunContext runContext = runContextFactory.of(Map.of());
+
+        WireMockServer wireMockServer = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        wireMockServer.start();
+
+        String previousBaseUrl = System.getProperty("notion.api.base.url");
+        System.setProperty("notion.api.base.url", wireMockServer.baseUrl());
+
+        try {
+            configureFor("localhost", wireMockServer.port());
+
+            wireMockServer.stubFor(
+                get(urlEqualTo("/v1/pages/" + pageId))
+                    .willReturn(
+                        aResponse()
+                            .withHeader("Content-Type", "application/json")
+                            .withBody(pageResponseJson(pageId, title))
+                            .withStatus(200)
+                    )
+            );
+
+            wireMockServer.stubFor(
+                patch(urlEqualTo("/v1/blocks/" + pageId + "/children"))
+                    .willReturn(
+                        aResponse()
+                            .withHeader("Content-Type", "application/json")
+                            .withBody("{\"object\":\"list\",\"results\":[]}")
+                            .withStatus(200)
+                    )
+            );
+
+            Update update = Update.builder()
+                .apiToken(Property.ofValue(apiToken))
+                .pageId(Property.ofValue(pageId))
+                .content(Property.ofValue(content.toString()))
+                .build();
+
+            update.run(runContext);
+
+            // The 150 blocks must be appended in two <=100-block batches, not one over-limit request.
+            verify(2, patchRequestedFor(urlEqualTo("/v1/blocks/" + pageId + "/children")));
         } finally {
             wireMockServer.stop();
             if (previousBaseUrl == null) {


### PR DESCRIPTION
## What
Fixes #57. `MarkdownConverter.markdownToBlocks` returns one flat array, and `page.Create` (create `children`), `page.Update` (append), and `database.CreateItem` (create `children`) each sent it in a single request. Notion caps a request at 100 blocks, so `content` producing >100 blocks failed with a `validation_error` (HTTP 400): `body.children.length should be ≤ 100`.

## How
A shared helper on `NotionConnection` paginates to the 100-block cap: `appendBlocksInBatches(...)` appends in ≤100-block batches in order, and `firstBlockBatch(...)` returns the first ≤100 for a create request. `Create`/`CreateItem` send the first batch inline then append the remainder (offset = `firstBatch.size()`, so it can't drift from the cap); `Update` loops its append. Content of ≤100 blocks is unchanged — a single request — so the common path doesn't regress.

## Testing
145 tests (3 pre-existing skips). New: `firstBlockBatch` cap (unit); WireMock boundary tests for Create (N=100 → single request/0 appends, N=101, N=150) and Update (>100 → multiple ≤100 batches). 

Verified end-to-end on a local Kestra 1.3: a 130-block page (which 400s on the released plugin) creates successfully:

 
<img width="400" alt="Screenshot 2026-07-02 at 18 12 12" src="https://github.com/user-attachments/assets/f6893714-c680-4ad3-9ef2-1e5046d4201d" />


## Out of scope
Pagination is not atomic: for >100-block content a failed request can leave a partial page, and a task retry may duplicate (Create makes a new page; Update re-appends). No 429/Retry-After backoff — configure retries via the task's HTTP `options` for very large content. A single block with >100 children (e.g. a 100+-row table) still exceeds Notion's limit; this paginates the top-level block array only. All three are noted on the tasks' `content` field.